### PR TITLE
Add context() to top of each test file.

### DIFF
--- a/tests/testthat/test_class.R
+++ b/tests/testthat/test_class.R
@@ -1,3 +1,5 @@
+context("Classes")
+
 library(testthat)
 library(yardstick)
 

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -1,3 +1,5 @@
+context("Multiple Metrics")
+
 library(testthat)
 library(yardstick)
 library(dplyr)

--- a/tests/testthat/test_regression.R
+++ b/tests/testthat/test_regression.R
@@ -1,3 +1,5 @@
+context("Regression Metrics")
+
 library(testthat)
 library(yardstick)
 

--- a/tests/testthat/test_regression_extra.R
+++ b/tests/testthat/test_regression_extra.R
@@ -1,3 +1,5 @@
+context("More Regression Metrics")
+
 library(testthat)
 library(yardstick)
 

--- a/tests/testthat/test_selectors.R
+++ b/tests/testthat/test_selectors.R
@@ -1,3 +1,5 @@
+context("Tidy Selectors")
+
 library(testthat)
 library(yardstick)
 library(tidyselect)
@@ -12,7 +14,7 @@ test_that('just factors', {
   expect_equal(
     yardstick:::factor_select(two_class_example, truth, predicted),
     list(truth = "truth", estimate = "predicted")
-  )  
+  )
   expect_equal(
     yardstick:::factor_select(two_class_example,
                               truth = truth,
@@ -33,7 +35,7 @@ test_that('just factors', {
   )
   expect_error(
     yardstick:::factor_select(two_class_example, truth = tru)
-  )  
+  )
 })
 
 ###################################################################
@@ -46,7 +48,7 @@ test_that('just probs', {
   expect_equal(
     yardstick:::prob_select(two_class_example, truth = truth, Class1),
     list(truth = "truth", probs = "Class1")
-  )  
+  )
   expect_error(
     yardstick:::prob_select(two_class_example,
                             truth = truth,
@@ -67,12 +69,12 @@ test_that('just probs', {
     yardstick:::prob_select(two_class_example,
                             truth = tru,
                             Class2)
-  )  
+  )
   expect_error(
     yardstick:::prob_select(two_class_example,
                             truth = truth,
                             Class)
-  )   
+  )
 })
 
 ###################################################################
@@ -82,13 +84,13 @@ test_that('both', {
     yardstick:::all_select(two_class_example,
                            truth = truth,
                            estimate = predicted,
-                           Class1), 
+                           Class1),
     list(truth = "truth", estimate = "predicted", probs = "Class1")
   )
   expect_equal(
-    yardstick:::all_select(two_class_example, truth, predicted, Class1, Class2), 
+    yardstick:::all_select(two_class_example, truth, predicted, Class1, Class2),
     list(truth = "truth", estimate = "predicted", probs = c("Class1", "Class2"))
-  )  
+  )
   expect_equal(
     yardstick:::all_select(two_class_example,
                            truth = truth,
@@ -103,17 +105,17 @@ test_that('both', {
   )
   expect_error(
     yardstick:::all_select(two_class_example, truth = tru)
-  )  
+  )
   expect_error(
     yardstick:::all_select(two_class_example,
                            truth = tru,
                            estimate = predicted,
                            Class2)
-  )  
+  )
   expect_error(
     yardstick:::all_select(two_class_example,
                            truth = truth,
                            estimate = predicted,
                            Class)
-  )     
+  )
 })

--- a/tests/testthat/test_two_class.R
+++ b/tests/testthat/test_two_class.R
@@ -1,3 +1,5 @@
+context("Two-class metrics")
+
 library(testthat)
 library(yardstick)
 library(pROC)


### PR DESCRIPTION
Fixes #22.

Looks like RStudio also cut some excess whitespace from the end of some lines; hope that's alright, happy to undo those if not.