### PR TITLE
Fix/respect na.rm

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -43,11 +43,21 @@ metric_vec_template <- function(metric_impl, truth, estimate,
     complete_cases <- complete.cases(truth, estimate)
     truth <- truth[complete_cases]
 
-    if(NCOL(estimate) == 1) {
+    if (NCOL(estimate) == 1) {
       estimate <- estimate[complete_cases]
-    } else {
+    }
+    else {
       # estimate can be a matrix
       estimate <- estimate[complete_cases, , drop = FALSE]
+    }
+
+  }
+  # na.rm = FALSE
+  # return NA if any NA
+  else {
+
+    if (anyNA(truth) || anyNA(estimate)) {
+      return(NA_real_)
     }
 
   }

--- a/tests/testthat/test_two_class.R
+++ b/tests/testthat/test_two_class.R
@@ -79,6 +79,10 @@ test_that('sensitivity', {
     sens(as.matrix(path_tbl))[[".estimate"]],
     231/258
   )
+  expect_equal(
+    sens(pathology, pathology, scan_na, na.rm = FALSE)[[".estimate"]],
+    NA_real_
+  )
 })
 
 
@@ -361,22 +365,22 @@ test_that('Log Loss', {
     mn_log_loss(ll_dat, truth = "obs", A, B, C, sum = TRUE)[[".estimate"]],
     -(log(1) + log(.8) + log(.51) + log(.8) + log(.6) + log(.4))
   )
-  
+
   # issue #29
-  x <- 
+  x <-
     structure(
       list(
         No = c(0.860384856004899, 1, 1),
         Yes = c(0.139615143995101, 0, 0),
         prob = c(0.139615143995101, 0, 0),
         estimate = structure(
-          c(1L, 1L, 1L), 
-          .Label = c("No", "Yes"), 
+          c(1L, 1L, 1L),
+          .Label = c("No", "Yes"),
           class = "factor"
         ),
         truth = structure(
-          c(2L, 1L, 2L), 
-          .Label = c("No", "Yes"), 
+          c(2L, 1L, 2L),
+          .Label = c("No", "Yes"),
           class = "factor"
         ),
         truth_num = c(1, 0, 1)
@@ -385,16 +389,16 @@ test_that('Log Loss', {
       class = c("tbl_df", "tbl", "data.frame")
     )
   expect_equal(
-    mn_log_loss(x[1:2,], truth = truth, No, Yes)[[".estimate"]], 
+    mn_log_loss(x[1:2,], truth = truth, No, Yes)[[".estimate"]],
     0.9844328,
     tol = .0001
   )
   expect_equal(
-    mn_log_loss(x, truth = truth, No, Yes)[[".estimate"]], 
+    mn_log_loss(x, truth = truth, No, Yes)[[".estimate"]],
     0.6562885,
     tol = .0001
   )
-  
+
 })
 
 x <- c(1, 1.2, 1.6, 2)


### PR DESCRIPTION
If `na.rm = FALSE`, this was not respected in classification metrics b/c of the default behavior of `table()` as documented in #41. This PR fixes this by exiting early from the metric function if any NA values are encountered.