### PR TITLE
Feature/improve metric set

### DIFF
--- a/R/classes-extra.R
+++ b/R/classes-extra.R
@@ -63,6 +63,8 @@ mcc <- function(data, ...) {
   UseMethod("mcc")
 }
 
+class(mcc) <- c("class_metric", "function")
+
 #' @export
 #' @rdname mcc
 mcc.data.frame <- function(data, truth, estimate,
@@ -176,6 +178,8 @@ j_index <- function(data, ...) {
   UseMethod("j_index")
 }
 
+class(j_index) <- c("class_metric", "function")
+
 #' @export
 #' @rdname mcc
 j_index.data.frame <- function(data, truth, estimate,
@@ -275,6 +279,8 @@ j_index_multiclass <- function(data, averaging) {
 bal_accuracy <- function(data, ...) {
   UseMethod("bal_accuracy")
 }
+
+class(bal_accuracy) <- c("class_metric", "function")
 
 #' @export
 #' @rdname mcc
@@ -377,6 +383,8 @@ bal_accuracy_multiclass <- function(data, averaging) {
 detection_prevalence <- function(data, ...) {
   UseMethod("detection_prevalence")
 }
+
+class(detection_prevalence) <- c("class_metric", "function")
 
 #' @export
 #' @rdname mcc

--- a/R/classes.R
+++ b/R/classes.R
@@ -55,6 +55,8 @@ accuracy <- function(data, ...) {
   UseMethod("accuracy")
 }
 
+class(accuracy) <- c("class_metric", "function")
+
 #' @export
 #' @rdname accuracy
 accuracy.data.frame <- function(data, truth, estimate,
@@ -131,6 +133,8 @@ accuracy_binary <- function(data) {
 kap <- function(data, ...) {
   UseMethod("kap")
 }
+
+class(kap) <- c("class_metric", "function")
 
 #' @export
 #' @rdname accuracy

--- a/R/gain-lift.R
+++ b/R/gain-lift.R
@@ -347,6 +347,8 @@ gain_capture <- function(data, ...) {
   UseMethod("gain_capture")
 }
 
+class(gain_capture) <- c("prob_metric", "function")
+
 #' @rdname gain_curve
 #' @export
 gain_capture.data.frame <- function(data, truth, estimate, na.rm = TRUE, ...) {

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -49,6 +49,8 @@
 #' # Multiclass metrics work, but you cannot specify any averaging
 #' # for roc_auc() besides the default, macro. Use the specific function
 #' # if you need more customization
+#' library(dplyr)
+#'
 #' hpc_cv %>%
 #'   group_by(Resample) %>%
 #'   metrics(obs, pred, VF:L) %>%

--- a/R/probs.R
+++ b/R/probs.R
@@ -130,8 +130,11 @@ NULL
 
 #' @export
 #' @rdname roc_auc
-roc_auc <- function(data, ...)
+roc_auc <- function(data, ...) {
   UseMethod("roc_auc")
+}
+
+class(roc_auc) <- c("prob_metric", "function")
 
 #' @export
 #' @rdname roc_auc
@@ -283,8 +286,11 @@ roc_auc_hand_till <- function(truth, estimate, options) {
 
 #' @export
 #' @rdname roc_auc
-pr_auc <- function(data, ...)
+pr_auc <- function(data, ...) {
   UseMethod("pr_auc")
+}
+
+class(pr_auc) <- c("prob_metric", "function")
 
 #' @export
 #' @rdname roc_auc
@@ -364,6 +370,8 @@ pr_auc_multiclass <- function(truth, estimate) {
 mn_log_loss <- function(data, ...) {
   UseMethod("mn_log_loss")
 }
+
+class(mn_log_loss) <- c("prob_metric", "function")
 
 #' @export
 #' @rdname roc_auc

--- a/R/probs.R
+++ b/R/probs.R
@@ -752,10 +752,13 @@ auc <- function(x, y, na.rm = TRUE) {
 # `...` -> estimate matrix / vector helper -------------------------------------
 
 dots_to_estimate <- function(data, ...) {
+
   # Capture dots
   dot_vars <- rlang::with_handlers(
     tidyselect::vars_select(names(data), !!! enquos(...)),
-    tidyselect_empty = abort_selection
+    tidyselect_empty_dots = function(cnd) {
+      abort("No valid variables provided to `...`.")
+    }
   )
 
   # estimate is a matrix of the selected columns if >1 selected

--- a/R/recall.R
+++ b/R/recall.R
@@ -89,6 +89,8 @@ recall <- function(data, ...) {
   UseMethod("recall")
 }
 
+class(recall) <- c("class_metric", "function")
+
 #' @rdname recall
 #' @export
 recall.data.frame <- function(data, truth, estimate,
@@ -201,6 +203,8 @@ recall_multiclass <- function(data, averaging) {
 precision <- function(data, ...) {
   UseMethod("precision")
 }
+
+class(precision) <- c("class_metric", "function")
 
 #' @rdname recall
 #' @export
@@ -320,6 +324,8 @@ precision_multiclass <- function(data, averaging) {
 f_meas <- function(data, ...) {
   UseMethod("f_meas")
 }
+
+class(f_meas) <- c("class_metric", "function")
 
 #' @rdname recall
 #' @export

--- a/R/regression-extra.R
+++ b/R/regression-extra.R
@@ -56,6 +56,8 @@ rpd <- function(data, ...) {
   UseMethod("rpd")
 }
 
+class(rpd) <- c("numeric_metric", "function")
+
 #' @rdname rpd
 #' @export
 rpd.data.frame <- function(data, truth, estimate, na.rm = TRUE, ...) {
@@ -101,6 +103,8 @@ rpd_vec <- function(truth, estimate, na.rm = TRUE, ...) {
 rpiq <- function(data, ...) {
   UseMethod("rpiq")
 }
+
+class(rpiq) <- c("numeric_metric", "function")
 
 #' @rdname rpd
 #' @export

--- a/R/regression.R
+++ b/R/regression.R
@@ -75,6 +75,8 @@ rmse <- function(data, ...) {
   UseMethod("rmse")
 }
 
+class(rmse) <- c("numeric_metric", "function")
+
 #' @rdname rmse
 #' @export
 rmse.data.frame <- function(data, truth, estimate, na.rm = TRUE, ...) {
@@ -117,6 +119,8 @@ rmse_vec <- function(truth, estimate, na.rm = TRUE, ...) {
 rsq <- function(data, ...) {
   UseMethod("rsq")
 }
+
+class(rsq) <- c("numeric_metric", "function")
 
 #' @rdname rmse
 #' @export
@@ -161,6 +165,8 @@ rsq_vec <- function(truth, estimate, na.rm = TRUE, ...) {
 rsq_trad <- function(data, ...) {
   UseMethod("rsq_trad")
 }
+
+class(rsq_trad) <- c("numeric_metric", "function")
 
 #' @rdname rmse
 #' @export
@@ -208,6 +214,8 @@ mae <- function(data, ...) {
   UseMethod("mae")
 }
 
+class(mae) <- c("numeric_metric", "function")
+
 #' @rdname rmse
 #' @export
 mae.data.frame <- function(data, truth, estimate, na.rm = TRUE, ...) {
@@ -251,6 +259,8 @@ mape <- function(data, ...) {
   UseMethod("mape")
 }
 
+class(mape) <- c("numeric_metric", "function")
+
 #' @rdname rmse
 #' @export
 mape.data.frame <- function(data, truth, estimate, na.rm = TRUE, ...) {
@@ -293,6 +303,8 @@ mape_vec <- function(truth, estimate, na.rm = TRUE, ...) {
 ccc <- function(data, ...) {
   UseMethod("ccc")
 }
+
+class(ccc) <- c("numeric_metric", "function")
 
 #' @rdname rmse
 #' @export

--- a/R/selectors.R
+++ b/R/selectors.R
@@ -10,10 +10,7 @@ abort_selection <- rlang::exiting(function(cnd) {
 
 prob_select <- function(data, truth, ...) {
   truth_var <- tidyselect::vars_pull(names(data), !! enquo(truth))
-  dot_vars <- rlang::with_handlers(
-    tidyselect::vars_select(names(data), !!! quos(...)),
-    tidyselect_empty = abort_selection
-  )
+  dot_vars <- tidyselect::vars_select(names(data), !!! quos(...))
   if (length(dot_vars) == 0) {
     stop("No class probability columns were selected by the `...`.",
          call. = FALSE)
@@ -35,10 +32,7 @@ all_select <- function(data, truth, estimate, ...) {
   truth_var <- tidyselect::vars_pull(names(data), !! enquo(truth))
   est_var <- tidyselect::vars_pull(names(data), !! enquo(estimate))
 
-  dot_vars <- rlang::with_handlers(
-    tidyselect::vars_select(names(data), !!! quos(...)),
-    tidyselect_empty = abort_selection
-  )
+  dot_vars <- tidyselect::vars_select(names(data), !!! quos(...))
 
   if (length(dot_vars) == 0) {
     dot_vars <- NA

--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -142,8 +142,11 @@ NULL
 
 #' @rdname sens
 #' @export
-sens <- function(data, ...)
+sens <- function(data, ...) {
   UseMethod("sens")
+}
+
+class(sens) <- c("class_metric", "function")
 
 #' @export
 #' @rdname sens
@@ -223,6 +226,8 @@ sens_table_impl <- recall_table_impl
 spec <-  function(data, ...) {
   UseMethod("spec")
 }
+
+class(spec) <- c("class_metric", "function")
 
 #' @export
 #' @rdname sens
@@ -350,6 +355,8 @@ spec_multiclass <- function(data, averaging) {
 ppv <- function(data, ...) {
   UseMethod("ppv")
 }
+
+class(ppv) <- c("class_metric", "function")
 
 #' @rdname sens
 #' @export
@@ -493,6 +500,8 @@ ppv_multiclass <- function(data, averaging, prevalence = NULL) {
 npv <- function(data, ...) {
   UseMethod("npv")
 }
+
+class(npv) <- c("class_metric", "function")
 
 #' @rdname sens
 #' @export

--- a/R/template.R
+++ b/R/template.R
@@ -1,6 +1,9 @@
 #' @importFrom dplyr summarise
-metric_summarizer <- function(metric_nm, metric_fn, data, truth, estimate,
-                              averaging = NA, na.rm = TRUE, ...,
+metric_summarizer <- function(metric_nm, metric_fn,
+                              data, truth, estimate,
+                              averaging = NA,
+                              na.rm = TRUE,
+                              ...,
                               metric_fn_options = list()) {
 
   truth <- enquo(truth)
@@ -13,7 +16,7 @@ metric_summarizer <- function(metric_nm, metric_fn, data, truth, estimate,
   truth <- handle_chr_names(truth)
   estimate <- handle_chr_names(estimate)
 
-  metric_tbl <- summarise(
+  metric_tbl <- dplyr::summarise(
     data,
     .metric = construct_name(!! metric_nm, averaging, !! estimate),
     .estimate = metric_fn(
@@ -28,20 +31,10 @@ metric_summarizer <- function(metric_nm, metric_fn, data, truth, estimate,
   dplyr::as_tibble(metric_tbl)
 }
 
-#' @importFrom rlang get_expr set_expr
-handle_chr_names <- function(x) {
-  x_expr <- get_expr(x)
-
-  # Replace character with bare name
-  if(is.character(x_expr) && length(x_expr) == 1) {
-    x <- set_expr(x, as.name(x_expr))
-  }
-
-  x
-}
 
 #' @importFrom stats complete.cases
-metric_vec_template <- function(metric_impl, truth, estimate,
+metric_vec_template <- function(metric_impl,
+                                truth, estimate,
                                 na.rm = TRUE,
                                 cls = "numeric",
                                 averaging = NULL,
@@ -74,6 +67,18 @@ metric_vec_template <- function(metric_impl, truth, estimate,
   }
 
   metric_impl(truth, estimate, ...)
+}
+
+#' @importFrom rlang get_expr set_expr
+handle_chr_names <- function(x) {
+  x_expr <- get_expr(x)
+
+  # Replace character with bare name
+  if(is.character(x_expr) && length(x_expr) == 1) {
+    x <- set_expr(x, as.name(x_expr))
+  }
+
+  x
 }
 
 metric_tibbler <- function(.metric, .estimate) {

--- a/man/metric_set.Rd
+++ b/man/metric_set.Rd
@@ -14,8 +14,10 @@ metric_set(...)
 into a new function that calculates all of them at once.
 }
 \details{
-There are currently no checks in place to ensure that all of the metric
-functions calculate the same kind of metric (regression vs classification).
+All functions must be of the same "function class" to be able to be used
+together. For instance, \code{rmse()} can be used with \code{mae()} because they
+are numeric metrics, but not with \code{accuracy()} because it is a classification
+metric.
 }
 \examples{
 
@@ -24,6 +26,8 @@ library(dplyr)
 # Multiple regression metrics
 multi_metric <- metric_set(rmse, rsq, ccc)
 
+# The returned function has arguments:
+# fn(data, truth, estimate, na.rm = TRUE, ...)
 multi_metric(solubility_test, truth = solubility, estimate = prediction)
 
 # Groups are respected on the new metric function
@@ -33,14 +37,34 @@ hpc_cv \%>\%
   group_by(Resample) \%>\%
   class_metrics(obs, pred)
 
+# ---------------------------------------------------------------------------
+
 # If you need to set options for certain metrics,
-# do so ahead of time with purrr::partial()
+# do so ahead of time with purrr::partial(). Unfortunately
+# this requires you to reset the class of the metric function manually
+# as partial() removes it. Metric function classes are one of:
+# "numeric_metric", "class_metric", "prob_metric"
 library(purrr)
 ccc_with_bias <- partial(ccc, bias = TRUE)
+class(ccc_with_bias) <- c("numeric_metric", "function")
 
 multi_metric2 <- metric_set(rmse, rsq, ccc_with_bias)
 
 multi_metric2(solubility_test, truth = solubility, estimate = prediction)
+
+# ---------------------------------------------------------------------------
+# A class probability example:
+
+# Note that, when given prob functions, metric_set() returns a function
+# with signature:
+# fn(data, truth, ...)
+# to be consistent with class probability metric functions
+
+probs_metrics <- metric_set(roc_auc, pr_auc, mn_log_loss)
+
+hpc_cv \%>\%
+  group_by(Resample) \%>\%
+  probs_metrics(obs, VF:L)
 
 }
 \seealso{

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -71,6 +71,8 @@ metrics(solubility_test, truth = solubility, estimate = prediction)
 # Multiclass metrics work, but you cannot specify any averaging
 # for roc_auc() besides the default, macro. Use the specific function
 # if you need more customization
+library(dplyr)
+
 hpc_cv \%>\%
   group_by(Resample) \%>\%
   metrics(obs, pred, VF:L) \%>\%

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -42,10 +42,12 @@ A two column tibble.
 \itemize{
 \item When \code{truth} is a factor, there are columns for \code{\link[=accuracy]{accuracy()}} and the
 Kappa statistic (\code{\link[=kap]{kap()}}).
-\item If a full set of class probability columns are passed to \code{...}, then
-there is also a column for \code{\link[=mn_log_loss]{mn_log_loss()}}.
-\item When \code{truth} has two levels and there are class probabilities, \code{\link[=roc_auc]{roc_auc()}}
-is appended.
+\item When \code{truth} has two levels, and 1 column of class probabilities is
+passed to \code{...}, there are columns for the two class versions of
+\code{\link[=mn_log_loss]{mn_log_loss()}} and \code{\link[=roc_auc]{roc_auc()}}.
+\item When \code{truth} has more than two levels, and a full set of class probabilities
+are passed to \code{...}, there are columns for the multiclass version of
+\code{\link[=mn_log_loss]{mn_log_loss()}} and macro averaged \code{\link[=roc_auc]{roc_auc()}}.
 \item When \code{truth} is numeric, there are columns for \code{\link[=rmse]{rmse()}}, \code{\link[=rsq]{rsq()}},
 and \code{\link[=mae]{mae()}}.
 }
@@ -65,6 +67,14 @@ metrics(two_class_example, truth, predicted, Class1)
 
 # Regression metrics
 metrics(solubility_test, truth = solubility, estimate = prediction)
+
+# Multiclass metrics work, but you cannot specify any averaging
+# for roc_auc() besides the default, macro. Use the specific function
+# if you need more customization
+hpc_cv \%>\%
+  group_by(Resample) \%>\%
+  metrics(obs, pred, VF:L) \%>\%
+  print(n = 40)
 
 }
 \seealso{

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -87,7 +87,6 @@ test_that('correct results', {
 test_that('custom metric sets', {
 
   reg_set <- metric_set(rmse, rsq, mae)
-  mixed_set <- metric_set(rmse, accuracy)
 
   expect_equal(
     reg_set(solubility_test, solubility, prediction),
@@ -98,6 +97,6 @@ test_that('custom metric sets', {
     metric_set(rmse, "x")
   )
   expect_error(
-    mixed_set(solubility_test, solubility, prediction),
+    metric_set(rmse, accuracy)
   )
 })

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -26,7 +26,7 @@ test_that('correct metrics returned', {
   )
   expect_equal(
     metrics(three_class, "obs", "pred", setosa, versicolor, virginica)[[".metric"]],
-    c("accuracy", "kap", "mn_log_loss")
+    c("accuracy", "kap", "mn_log_loss", "roc_auc_macro")
   )
   expect_equal(
     metrics(solubility_test, solubility, "prediction")[[".metric"]],


### PR DESCRIPTION
- improve `metric_set()` by bundling metric functions into 3 buckets so we can ensure that only functions in the same bucket can be used together
- update `metrics()` a bit to work with multiclass support for `roc_auc()` and grouped data frames for `accuracy()` and `kap()`.