### PR TITLE
missing validation in metrics

### DIFF
--- a/R/metrics.R
+++ b/R/metrics.R
@@ -72,11 +72,17 @@ metrics <- function(data, ...) {
 metrics.data.frame <- function(data, truth, estimate, ...,
                                options = list(), na_rm = TRUE) {
 
+  truth <- enquo(truth)
+  estimate <- enquo(estimate)
+
+  validate_not_missing(truth, "truth")
+  validate_not_missing(estimate, "estimate")
+
   # Get set of character vars
   vars <- all_select(
     data = data,
-    truth = !!enquo(truth),
-    estimate = !!enquo(estimate),
+    truth = !!truth,
+    estimate = !!estimate,
     ...
   )
 

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -72,17 +72,11 @@ metrics <- function(data, ...) {
 metrics.data.frame <- function(data, truth, estimate, ...,
                                options = list(), na_rm = TRUE) {
 
-  truth <- enquo(truth)
-  estimate <- enquo(estimate)
-
-  validate_not_missing(truth, "truth")
-  validate_not_missing(estimate, "estimate")
-
   # Get set of character vars
   vars <- all_select(
     data = data,
-    truth = !!truth,
-    estimate = !!estimate,
+    truth = !!enquo(truth),
+    estimate = !!enquo(estimate),
     ...
   )
 

--- a/R/selectors.R
+++ b/R/selectors.R
@@ -24,8 +24,15 @@ prob_select <- function(data, truth, ...) {
 }
 
 all_select <- function(data, truth, estimate, ...) {
-  truth_var <- tidyselect::vars_pull(names(data), !! enquo(truth))
-  est_var <- tidyselect::vars_pull(names(data), !! enquo(estimate))
+
+  truth <- enquo(truth)
+  estimate <- enquo(estimate)
+
+  validate_not_missing(truth, "truth")
+  validate_not_missing(estimate, "estimate")
+
+  truth_var <- tidyselect::vars_pull(names(data), !! truth)
+  est_var <- tidyselect::vars_pull(names(data), !! estimate)
 
   dot_vars <- tidyselect::vars_select(names(data), !!! quos(...))
 


### PR DESCRIPTION
I noticed that `metrics()` was the only function that didn't validate the `truth` and `estimate` argument, so I added tests using the helper function `validate_not_missing()`.