### PR TITLE
adding autoplot method for conf_mat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 * `smape()` is a numeric metric that is based on percentage errors 
 (@riazhedayati, #67).
 
+* `conf_mat()` got two `ggplot2::autoplot()` methods for easy visualization 
+(@EmilHvitfeldt, $10).
+
 # yardstick 0.0.2
 
 ## Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 (@riazhedayati, #67).
 
 * `conf_mat()` got two `ggplot2::autoplot()` methods for easy visualization 
-(@EmilHvitfeldt, $10).
+(@EmilHvitfeldt, #10).
 
 # yardstick 0.0.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,8 @@
 * `smape()` is a numeric metric that is based on percentage errors 
 (@riazhedayati, #67).
 
-* `conf_mat()` got two `ggplot2::autoplot()` methods for easy visualization 
-(@EmilHvitfeldt, #10).
+* `conf_mat` objects now have two  `ggplot2::autoplot()`methods for easy visualization
+of the confusion matrix as either a heat map or a mosaic plot (@EmilHvitfeldt, #10).
 
 # yardstick 0.0.2
 

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -28,7 +28,7 @@ utils::globalVariables(
     ".percent_tested",
     "Prediction",
     "Truth",
-    "Count",
+    "Freq",
     "xmin",
     "xmax",
     "ymin",

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -25,7 +25,14 @@ utils::globalVariables(
     "perfect",
     "sensitivity",
     ".percent_found",
-    ".percent_tested"
+    ".percent_tested",
+    "Prediction",
+    "Truth",
+    "Count",
+    "xmin",
+    "xmax",
+    "ymin",
+    "ymax"
   )
 )
 
@@ -48,6 +55,7 @@ utils::globalVariables(
   s3_register("ggplot2::autoplot", "lift_df")
   s3_register("ggplot2::autoplot", "roc_df")
   s3_register("ggplot2::autoplot", "pr_df")
+  s3_register("ggplot2::autoplot", "conf_mat")
 
   invisible()
 }

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -83,7 +83,7 @@
 #'
 #' round(mean_cmat, 3)
 #'
-#' # The confusion matrix can quickly be vizualized using autoplot()
+#' # The confusion matrix can quickly be visualized using autoplot()
 #' library(ggplot2)
 #'
 #' autoplot(cm, type = "mosaic")

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -316,7 +316,7 @@ cm_heat <- function(x) {
     ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Freq)) %+%
     ggplot2::geom_tile() %+%
     ggplot2::scale_fill_gradient(low = "white", high = "black") %+%
-    ggplot2::theme_bw()
+    ggplot2::theme(panel.background = ggplot2::element_blank())
 }
 
 space_fun <- function(x, adjustment, rescale = FALSE) {

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -312,13 +312,8 @@ cm_heat <- function(x) {
 
   `%+%` <- ggplot2::`%+%`
 
-  data <- as.data.frame.matrix(x$table)
-
-  data$Prediction <- rownames(data)
-
-  data %>%
-    tidyr::gather(key = "Truth", value = "Count", -Prediction) %>%
-    ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Count)) %+%
+  as.data.frame.table(x$table) %>%
+    ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Freq)) %+%
     ggplot2::geom_tile() %+%
     ggplot2::scale_fill_gradient(low = "white", high = "black") %+%
     ggplot2::theme_bw()

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -315,8 +315,9 @@ cm_heat <- function(x) {
   as.data.frame.table(x$table) %>%
     ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Freq)) %+%
     ggplot2::geom_tile() %+%
-    ggplot2::scale_fill_gradient(low = "white", high = "black") %+%
-    ggplot2::theme(panel.background = ggplot2::element_blank())
+    ggplot2::scale_fill_gradient(low = "grey90", high = "grey40") %+%
+    ggplot2::theme(panel.background = ggplot2::element_blank(), legend.position = "none") %+%
+    ggplot2::geom_text(ggplot2::aes(label = Freq))
 }
 
 space_fun <- function(x, adjustment, rescale = FALSE) {

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -313,14 +313,12 @@ cm_heat <- function(x) {
   `%+%` <- ggplot2::`%+%`
 
   as.data.frame.table(x$table) %>%
-    ggplot2::ggplot(ggplot2::aes(x = Prediction,
-                                 y = factor(Truth, levels = rev(levels(Truth))),
-                                 fill = Freq)) %+%
+    dplyr::mutate(Truth = factor(Truth, levels = rev(levels(Truth)))) %>%
+    ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Freq)) %+%
     ggplot2::geom_tile() %+%
     ggplot2::scale_fill_gradient(low = "grey90", high = "grey40") %+%
     ggplot2::theme(panel.background = ggplot2::element_blank(), legend.position = "none") %+%
-    ggplot2::geom_text(ggplot2::aes(label = Freq)) %+%
-    ggplot2::labs(y = "Truth")
+    ggplot2::geom_text(ggplot2::aes(label = Freq))
 }
 
 space_fun <- function(x, adjustment, rescale = FALSE) {

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -313,11 +313,14 @@ cm_heat <- function(x) {
   `%+%` <- ggplot2::`%+%`
 
   as.data.frame.table(x$table) %>%
-    ggplot2::ggplot(ggplot2::aes(Prediction, Truth, fill = Freq)) %+%
+    ggplot2::ggplot(ggplot2::aes(x = Prediction,
+                                 y = factor(Truth, levels = rev(levels(Truth))),
+                                 fill = Freq)) %+%
     ggplot2::geom_tile() %+%
     ggplot2::scale_fill_gradient(low = "grey90", high = "grey40") %+%
     ggplot2::theme(panel.background = ggplot2::element_blank(), legend.position = "none") %+%
-    ggplot2::geom_text(ggplot2::aes(label = Freq))
+    ggplot2::geom_text(ggplot2::aes(label = Freq)) %+%
+    ggplot2::labs(y = "Truth")
 }
 
 space_fun <- function(x, adjustment, rescale = FALSE) {

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -113,7 +113,7 @@ colnames(mean_cmat) <- levels(hpc_cv$obs)
 
 round(mean_cmat, 3)
 
-# The confusion matrix can quickly be vizualized using autoplot()
+# The confusion matrix can quickly be visualized using autoplot()
 library(ggplot2)
 
 autoplot(cm, type = "mosaic")

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -6,6 +6,7 @@
 \alias{conf_mat.default}
 \alias{conf_mat.data.frame}
 \alias{tidy.conf_mat}
+\alias{autoplot.conf_mat}
 \title{Confusion Matrix for Categorical Data}
 \usage{
 conf_mat(data, ...)
@@ -14,6 +15,8 @@ conf_mat(data, ...)
   dnn = c("Prediction", "Truth"), ...)
 
 \method{tidy}{conf_mat}(x, ...)
+
+autoplot.conf_mat(object, type = "mosaic", ...)
 }
 \arguments{
 \item{data}{A data frame or a \code{\link[base:table]{base::table()}}.}
@@ -36,6 +39,11 @@ unquoted variable name. For \code{_vec()} functions, a \code{factor} vector.}
 \item{dnn}{A character vector of dimnames for the table.}
 
 \item{x}{A \code{conf_mat} object.}
+
+\item{object}{The \code{conf_mat} data frame returned from \code{conf_mat()}.}
+
+\item{type}{Type of plot desired, must be "mosaic" or "heatmap",
+defaults to "mosaic".}
 }
 \value{
 \code{conf_mat()} produces an object with class \code{conf_mat}. This contains the
@@ -57,6 +65,10 @@ easy manipulation.
 There is also a \code{summary()} method that computes various classification
 metrics at once. See \code{\link[=summary.conf_mat]{summary.conf_mat()}}
 
+There is a \code{\link[ggplot2:autoplot]{ggplot2::autoplot()}}
+method for quickly visualizing the matrix. Both a heatmap and mosaic type
+is implemented.
+
 The function requires that the factors have exactly the same levels.
 }
 \examples{
@@ -64,9 +76,10 @@ library(dplyr)
 data("hpc_cv")
 
 # The confusion matrix from a single assessment set (i.e. fold)
-hpc_cv \%>\%
+cm <- hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
   conf_mat(obs, pred)
+cm
 
 # Now compute the average confusion matrix across all folds in
 # terms of the proportion of the data contained in each cell.
@@ -99,6 +112,13 @@ rownames(mean_cmat) <- levels(hpc_cv$obs)
 colnames(mean_cmat) <- levels(hpc_cv$obs)
 
 round(mean_cmat, 3)
+
+# The confusion matrix can quickly be vizualized using autoplot()
+library(ggplot2)
+
+autoplot(cm, type = "mosaic")
+autoplot(cm, type = "heatmap")
+
 }
 \seealso{
 \code{\link[=summary.conf_mat]{summary.conf_mat()}} for computing a large number of metrics from one

--- a/tests/testthat/test_autoplot.R
+++ b/tests/testthat/test_autoplot.R
@@ -303,3 +303,67 @@ test_that("Lift Curve - multi class, with resamples", {
   # 5 resamples
   expect_equal(length(unique(.plot_data$data[[1]]$colour)), 5)
 })
+
+# Confusion Matrix  ------------------------------------------------------------
+test_that("Confusion Matrix - type argument", {
+  res <- conf_mat(two_class_example, truth, predicted)
+
+  expect_error(.plot <- autoplot(res, type = "wrong"), "type")
+})
+
+test_that("Confusion Matrix - two class - heatmap", {
+  res <- conf_mat(two_class_example, truth, predicted)
+
+  expect_error(.plot <- autoplot(res, type = "heatmap"), NA)
+  expect_is(.plot, "gg")
+
+  .plot_data <- ggplot_build(.plot)
+
+
+  # 4 panes
+  expect_equal(nrow(.plot_data$data[[1]]), length(res$table))
+})
+
+test_that("Confusion Matrix - multi class - heatmap", {
+  res <- hpc_cv %>%
+    filter(Resample == "Fold01") %>%
+    conf_mat(obs, pred)
+
+  expect_error(.plot <- autoplot(res, type = "heatmap"), NA)
+  expect_is(.plot, "gg")
+
+  .plot_data <- ggplot_build(.plot)
+
+
+  # panes
+  expect_equal(nrow(.plot_data$data[[1]]), length(res$table))
+})
+
+test_that("Confusion Matrix - two class - mosaic", {
+  res <- conf_mat(two_class_example, truth, predicted)
+
+  expect_error(.plot <- autoplot(res, type = "mosaic"), NA)
+  expect_is(.plot, "gg")
+
+  .plot_data <- ggplot_build(.plot)
+
+
+  # 4 panes
+  expect_equal(nrow(.plot_data$data[[1]]), length(res$table))
+})
+
+test_that("Confusion Matrix - multi class - mosaic", {
+  res <- hpc_cv %>%
+    filter(Resample == "Fold01") %>%
+    conf_mat(obs, pred)
+
+  expect_error(.plot <- autoplot(res, type = "mosaic"), NA)
+  expect_is(.plot, "gg")
+
+  .plot_data <- ggplot_build(.plot)
+
+  # panes
+  expect_equal(nrow(.plot_data$data[[1]]), length(res$table))
+
+})
+


### PR DESCRIPTION
I gave a shot at #10, I couldn't decide between the standardly used heatmap and the mosaic plot so I added both.

``` r
library(tidymodels)
cm_small <- conf_mat(two_class_example, truth, predicted)

cm_big <- hpc_cv %>%
  filter(Resample == "Fold01") %>%
  conf_mat(obs, pred)

autoplot(cm_small)
```

![](https://i.imgur.com/V7dmlTf.png)

``` r
autoplot(cm_big)
```

![](https://i.imgur.com/HYo0Wt3.png)

``` r

autoplot(cm_small, type = "heatmap")
```

![](https://i.imgur.com/vuQTiZJ.png)

``` r
autoplot(cm_big, type = "heatmap")
```

![](https://i.imgur.com/xawBp53.png)

<sup>Created on 2019-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

with the standard ggplot-ness scales can be changed again

``` r
autoplot(cm_small, type = "heatmap") +
  scale_fill_gradient(low = "white", high = "darkred")

```

![](https://i.imgur.com/Bygmlw3.png)

<sup>Created on 2019-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
