### PR TITLE
Ensure that `f_meas()` propagates `NA` values from `precision()` and `recall()`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@ are used, a `"class_prob_metric_set"` is returned.
 
 * Tests related to the fixed R 3.6 `sample()` function have been fixed.
 
+* `f_meas()` propagates `NA` values from `precision()` and `recall()` correctly.
+
 # yardstick 0.0.2
 
 ## Breaking changes

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -132,7 +132,7 @@ f_meas_binary <- function(data, beta = 1) {
   rec <- recall_binary(data)
 
   # if precision and recall are both 0, return 0 not NA
-  if(precision == 0 & rec == 0) {
+  if(isTRUE(precision == 0 & rec == 0)) {
     return(0)
   }
 

--- a/tests/testthat/test-class-f_meas.R
+++ b/tests/testthat/test-class-f_meas.R
@@ -24,6 +24,57 @@ test_that('Two class - Powers paper', {
   )
 })
 
+# ------------------------------------------------------------------------------
+# Issue #77
+
+test_that("`NA` values propagate from binary `precision()`", {
+
+  truth <- factor(c(rep("a", 2), rep("b", 2)))
+  estimate <- factor(rep("b", length(truth)), levels(truth))
+
+  expect_equal(
+    precision_vec(truth, estimate),
+    f_meas_vec(truth, estimate)
+  )
+
+})
+
+test_that("`NA` values propagate from binary `recall()`", {
+
+  estimate <- factor(c(rep("a", 2), rep("b", 2)))
+  truth <- factor(rep("b", length(estimate)), levels(estimate))
+
+  expect_equal(
+    recall_vec(truth, estimate),
+    f_meas_vec(truth, estimate)
+  )
+
+})
+
+test_that("`NA` values propagate from multiclass `precision()`", {
+
+  truth <- factor(c(rep("a", 2), rep("b", 2)))
+  estimate <- factor(rep("b", length(truth)), levels(truth))
+
+  expect_equal(
+    precision_vec(truth, estimate, estimator = "macro"),
+    f_meas_vec(truth, estimate, estimator = "macro")
+  )
+
+})
+
+test_that("`NA` values propagate from multiclass `recall()`", {
+
+  estimate <- factor(c(rep("a", 2), rep("b", 2)))
+  truth <- factor(rep("b", length(estimate)), levels(estimate))
+
+  expect_equal(
+    recall_vec(truth, estimate, estimator = "macro"),
+    f_meas_vec(truth, estimate, estimator = "macro")
+  )
+
+})
+
 # sklearn compare --------------------------------------------------------------
 
 py_res <- read_pydata("py-f_meas")


### PR DESCRIPTION
Closes #77.