### PR TITLE
Added more description to all .Rd help files involving classification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Imports:
     rlang,
     tidyselect,
     Rcpp,
-    generics
+    generics,
+    forcats
 LinkingTo: 
     Rcpp
 VignetteBuilder: knitr

--- a/R/data.R
+++ b/R/data.R
@@ -23,17 +23,17 @@ NULL
 
 #' Solubility Predictions from MARS Model
 #'
-#' @details For the solubility data in Kuhn and Johnson (2013), 
+#' @details For the solubility data in Kuhn and Johnson (2013),
 #'  these data are the test set results for the MARS model. The
 #'  observed solubility (in column `solubility`) and the model
-#'  results (`prediction`) are contained in the data. 
+#'  results (`prediction`) are contained in the data.
 #'
 #' @name solubility_test
 #' @aliases solubility_test
 #' @docType data
 #' @return \item{solubility_test}{a data frame}
 #'
-#' @source Kuhn, M., Johnson, K. (2013) *Applied Predictive 
+#' @source Kuhn, M., Johnson, K. (2013) *Applied Predictive
 #'  Modeling*, Springer
 #'
 #' @keywords datasets
@@ -43,7 +43,7 @@ NULL
 NULL
 
 
-#' Class Probability Predictions
+#' Multiclass Probability Predictions
 #'
 #' @details This data frame contains the predicted classes and
 #'  class probabilities for a linear discriminant analysis model fit
@@ -59,13 +59,17 @@ NULL
 #' @docType data
 #' @return \item{hpc_cv}{a data frame}
 #'
-#' @source Kuhn, M., Johnson, K. (2013) *Applied Predictive 
+#' @source Kuhn, M., Johnson, K. (2013) *Applied Predictive
 #'  Modeling*, Springer
 #'
 #' @keywords datasets
 #' @examples
 #' data(hpc_cv)
 #' str(hpc_cv)
+#'
+#' # obs variable is a four-level factor with the first level set to be "VF" and
+#' # thus obs == "VF" is the event of interest for binary classification.
+#' levels(hpc_cv$obs)
 NULL
 
 
@@ -85,5 +89,10 @@ NULL
 #' @examples
 #' data(two_class_example)
 #' str(two_class_example)
+#'
+#' # truth variable is a two-level factor with the first level set to be
+#' # "Class1" and thus truth == "Class1" is the event of interest for binary
+#' # classification.
+#' levels(hpc_cv$obs)
 NULL
 

--- a/R/prob-gain_capture.R
+++ b/R/prob-gain_capture.R
@@ -34,7 +34,10 @@
 #'
 #' [gain_curve()] to compute the full gain curve.
 #'
-#' @template examples-prob
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
+#' @template examples-multiclass-example
+#' @template examples-multiclass-prob
 #' @examples
 #' # Visualize gain_capture() --------------------------------------------------
 #'

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -36,6 +36,7 @@
 #' entire number of true results are found. This is the y-axis in a gain chart.
 #'
 #' @family curve metrics
+#' @templateVar metric_fn gain_curve
 #' @template multiclass-curve
 #' @template event_first
 #'
@@ -65,15 +66,13 @@
 #'
 #' @author Max Kuhn
 #'
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
 #' @examples
-#' library(ggplot2)
-#' library(dplyr)
-#'
-#' # Two class - a tibble is returned
-#' gain_curve(two_class_example, truth, Class1)
-#'
 #' # Use autoplot to visualize
 #' # The top left hand corner of the grey triangle is a "perfect" gain curve
+#' library(ggplot2)
+#' library(dplyr)
 #' autoplot(gain_curve(two_class_example, truth, Class1))
 #'
 #' # Multiclass one-vs-all approach

--- a/R/prob-lift_curve.R
+++ b/R/prob-lift_curve.R
@@ -34,6 +34,7 @@
 #' y-axis of the lift chart.
 #'
 #' @family curve metrics
+#' @templateVar metric_fn lift_curve
 #' @template multiclass-curve
 #' @template event_first
 #'
@@ -53,14 +54,12 @@
 #'
 #' @author Max Kuhn
 #'
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
 #' @examples
+#' # Use autoplot to visualize
 #' library(ggplot2)
 #' library(dplyr)
-#'
-#' # Two class - a tibble is returned
-#' lift_curve(two_class_example, truth, Class1)
-#'
-#' # Use autoplot to visualize
 #' autoplot(lift_curve(two_class_example, truth, Class1))
 #'
 #' # Multiclass one-vs-all approach

--- a/R/prob-pr_auc.R
+++ b/R/prob-pr_auc.R
@@ -37,7 +37,10 @@
 #'
 #' @author Max Kuhn
 #'
-#' @template examples-prob
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
+#' @template examples-multiclass-example
+#' @template examples-multiclass-prob
 #'
 #' @export
 pr_auc <- function(data, ...) {

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -12,6 +12,7 @@
 #'  resamples). See the examples.
 #'
 #' @family curve metrics
+#' @templateVar metric_fn pr_curve
 #' @template multiclass-curve
 #' @template event_first
 #'
@@ -26,15 +27,12 @@
 #' Compute the area under the precision recall curve with [pr_auc()].
 #'
 #' @author Max Kuhn
-#'
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
 #' @examples
+#' # Visualize the curve using ggplot2 manually
 #' library(ggplot2)
 #' library(dplyr)
-#'
-#' # Two class - a tibble is returned
-#' pr_curve(two_class_example, truth, Class1)
-#'
-#' # Visualize the curve using ggplot2 manually
 #' pr_curve(two_class_example, truth, Class1) %>%
 #'   ggplot(aes(x = recall, y = precision)) +
 #'   geom_path() +

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -60,7 +60,10 @@
 #'
 #' @author Max Kuhn
 #'
-#' @template examples-prob
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
+#' @template examples-multiclass-example
+#' @template examples-multiclass-prob
 #' @examples
 #' # passing options via a list and _not_ `...`
 #' roc_auc(two_class_example, truth = truth, Class1,

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -16,6 +16,7 @@
 #'  resamples). See the examples.
 #'
 #' @family curve metrics
+#' @templateVar metric_fn roc_curve
 #' @template multiclass-curve
 #' @template event_first
 #'
@@ -33,15 +34,12 @@
 #' Compute the area under the ROC curve with [roc_auc()].
 #'
 #' @author Max Kuhn
-#'
+#' @template examples-two-class-example
+#' @template examples-two-class-prob
 #' @examples
+#' # Visualize the curve using ggplot2 manually
 #' library(ggplot2)
 #' library(dplyr)
-#'
-#' # Two class - a tibbble is returned
-#' roc_curve(two_class_example, truth, Class1)
-#'
-#' # Visualize the curve using ggplot2 manually
 #' roc_curve(two_class_example, truth, Class1) %>%
 #'   ggplot(aes(x = 1 - specificity, y = sensitivity)) +
 #'   geom_path() +

--- a/man-roxygen/event_first.R
+++ b/man-roxygen/event_first.R
@@ -6,6 +6,7 @@
 #' change this, a global option called `yardstick.event_first` is
 #' set to `TRUE` when the package is loaded. This can be changed
 #' to `FALSE` if the last level of the factor is considered the
-#' level of interest. For multiclass extensions involving one-vs-all
+#' level of interest by running: `options(yardstick.event_first = FALSE)`.
+#' For multiclass extensions involving one-vs-all
 #' comparisons (such as macro averaging), this option is ignored and
 #' the "one" level is always the relevant result.

--- a/man-roxygen/examples-multiclass-example.R
+++ b/man-roxygen/examples-multiclass-example.R
@@ -1,0 +1,6 @@
+#' @examples
+#' # Multiclass example: obs variable is a four-level factor with the first
+#' # level set to be "VF" and thus obs == "VF" is the event of interest.
+#' data(hpc_cv)
+#' levels(hpc_cv$obs)
+#'

--- a/man-roxygen/examples-multiclass-prob.R
+++ b/man-roxygen/examples-multiclass-prob.R
@@ -1,5 +1,6 @@
 #' @examples
 #' # You can use the col1:colN tidyselect syntax
+#' library(dplyr)
 #' hpc_cv %>%
 #'   filter(Resample == "Fold01") %>%
 #'   <%=metric_fn %>(obs, VF:L)

--- a/man-roxygen/examples-multiclass-prob.R
+++ b/man-roxygen/examples-multiclass-prob.R
@@ -1,0 +1,37 @@
+#' @examples
+#' # You can use the col1:colN tidyselect syntax
+#' hpc_cv %>%
+#'   filter(Resample == "Fold01") %>%
+#'   <%=metric_fn %>(obs, VF:L)
+#'
+#' # Change the first level of obs variable from "VF" to "M" and thus the
+#' # event of interest is now "obs" == "M".
+#' library(forcats)
+#' hpc_cv %>%
+#'   filter(Resample == "Fold01") %>%
+#'   mutate(obs = fct_relevel(obs, "M")) %>%
+#'   <%=metric_fn %>(obs, VF:L)
+#'
+#' # Groups are respected
+#' hpc_cv %>%
+#'   group_by(Resample) %>%
+#'   <%=metric_fn %>(obs, VF:L)
+#'
+#' # Weighted macro averaging
+#' hpc_cv %>%
+#'   group_by(Resample) %>%
+#'   <%=metric_fn %>(obs, VF:L, estimator = "macro_weighted")
+#'
+#' # Vector version
+#' # Supply a matrix of class probabilities
+#' fold1 <- hpc_cv %>%
+#'   filter(Resample == "Fold01")
+#'
+#' <%=metric_fn %>_vec(
+#'    truth = fold1$obs,
+#'    matrix(
+#'      c(fold1$VF, fold1$F, fold1$M, fold1$L),
+#'      ncol = 4
+#'    )
+#' )
+#'

--- a/man-roxygen/examples-two-class-example.R
+++ b/man-roxygen/examples-two-class-example.R
@@ -1,0 +1,7 @@
+#' @examples
+#' # Two class example: truth variable is a two-level factor with the first
+#' # level set to be "Class1" and thus truth == "Class1" is the event of
+#' # interest (see "Relevant level" section above)
+#' data("two_class_example")
+#' levels(two_class_example$truth)
+#'

--- a/man-roxygen/examples-two-class-prob.R
+++ b/man-roxygen/examples-two-class-prob.R
@@ -1,0 +1,6 @@
+#' @examples
+#' # Since "Class1" is the event of interest, the third argument of function
+#' # are the "Class1" probabilities stored in Class1 variable. A tibble is
+#' # returned.
+#' <%=metric_fn %>(two_class_example, truth, Class1)
+#'

--- a/man/bal_accuracy.Rd
+++ b/man/bal_accuracy.Rd
@@ -61,7 +61,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -16,7 +16,7 @@ conf_mat(data, ...)
 
 \method{tidy}{conf_mat}(x, ...)
 
-\method{autoplot}{conf_mat}(object, type = "mosaic", ...)
+autoplot.conf_mat(object, type = "mosaic", ...)
 }
 \arguments{
 \item{data}{A data frame or a \code{\link[base:table]{base::table()}}.}

--- a/man/detection_prevalence.Rd
+++ b/man/detection_prevalence.Rd
@@ -63,7 +63,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/f_meas.Rd
+++ b/man/f_meas.Rd
@@ -73,7 +73,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/gain_capture.Rd
+++ b/man/gain_capture.Rd
@@ -90,17 +90,33 @@ See \code{vignette("multiclass", "yardstick")} for more information.
 }
 
 \examples{
-# Two class
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
 data("two_class_example")
+levels(two_class_example$truth)
+
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 gain_capture(two_class_example, truth, Class1)
 
-# Multiclass
-library(dplyr)
+# Multiclass example: obs variable is a four-level factor with the first
+# level set to be "VF" and thus obs == "VF" is the event of interest.
 data(hpc_cv)
+levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
+  gain_capture(obs, VF:L)
+
+# Change the first level of obs variable from "VF" to "M" and thus the
+# event of interest is now "obs" == "M".
+library(forcats)
+hpc_cv \%>\%
+  filter(Resample == "Fold01") \%>\%
+  mutate(obs = fct_relevel(obs, "M")) \%>\%
   gain_capture(obs, VF:L)
 
 # Groups are respected

--- a/man/gain_capture.Rd
+++ b/man/gain_capture.Rd
@@ -108,6 +108,7 @@ data(hpc_cv)
 levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
+library(dplyr)
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
   gain_capture(obs, VF:L)

--- a/man/gain_capture.Rd
+++ b/man/gain_capture.Rd
@@ -75,7 +75,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/gain_curve.Rd
+++ b/man/gain_curve.Rd
@@ -10,7 +10,7 @@ gain_curve(data, ...)
 
 \method{gain_curve}{data.frame}(data, truth, ..., na_rm = TRUE)
 
-\method{autoplot}{gain_df}(object, ...)
+autoplot.gain_df(object, ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}

--- a/man/gain_curve.Rd
+++ b/man/gain_curve.Rd
@@ -107,14 +107,21 @@ the "one" level is always the relevant result.
 }
 
 \examples{
-library(ggplot2)
-library(dplyr)
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
+data("two_class_example")
+levels(two_class_example$truth)
 
-# Two class - a tibble is returned
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 gain_curve(two_class_example, truth, Class1)
 
 # Use autoplot to visualize
 # The top left hand corner of the grey triangle is a "perfect" gain curve
+library(ggplot2)
+library(dplyr)
 autoplot(gain_curve(two_class_example, truth, Class1))
 
 # Multiclass one-vs-all approach

--- a/man/gain_curve.Rd
+++ b/man/gain_curve.Rd
@@ -101,7 +101,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/hpc_cv.Rd
+++ b/man/hpc_cv.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{hpc_cv}
 \alias{hpc_cv}
-\title{Class Probability Predictions}
+\title{Multiclass Probability Predictions}
 \source{
 Kuhn, M., Johnson, K. (2013) \emph{Applied Predictive
 Modeling}, Springer
@@ -12,7 +12,7 @@ Modeling}, Springer
 \item{hpc_cv}{a data frame}
 }
 \description{
-Class Probability Predictions
+Multiclass Probability Predictions
 }
 \details{
 This data frame contains the predicted classes and
@@ -27,5 +27,9 @@ the resample indicator is included.
 \examples{
 data(hpc_cv)
 str(hpc_cv)
+
+# obs variable is a four-level factor with the first level set to be "VF" and
+# thus obs == "VF" is the event of interest for binary classification.
+levels(hpc_cv$obs)
 }
 \keyword{datasets}

--- a/man/j_index.Rd
+++ b/man/j_index.Rd
@@ -73,7 +73,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/lift_curve.Rd
+++ b/man/lift_curve.Rd
@@ -98,7 +98,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/lift_curve.Rd
+++ b/man/lift_curve.Rd
@@ -104,13 +104,20 @@ the "one" level is always the relevant result.
 }
 
 \examples{
-library(ggplot2)
-library(dplyr)
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
+data("two_class_example")
+levels(two_class_example$truth)
 
-# Two class - a tibble is returned
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 lift_curve(two_class_example, truth, Class1)
 
 # Use autoplot to visualize
+library(ggplot2)
+library(dplyr)
 autoplot(lift_curve(two_class_example, truth, Class1))
 
 # Multiclass one-vs-all approach

--- a/man/lift_curve.Rd
+++ b/man/lift_curve.Rd
@@ -10,7 +10,7 @@ lift_curve(data, ...)
 
 \method{lift_curve}{data.frame}(data, truth, ..., na_rm = TRUE)
 
-\method{autoplot}{lift_df}(object, ...)
+autoplot.lift_df(object, ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}

--- a/man/mcc.Rd
+++ b/man/mcc.Rd
@@ -54,7 +54,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/npv.Rd
+++ b/man/npv.Rd
@@ -73,7 +73,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/ppv.Rd
+++ b/man/ppv.Rd
@@ -73,7 +73,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/pr_auc.Rd
+++ b/man/pr_auc.Rd
@@ -97,6 +97,7 @@ data(hpc_cv)
 levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
+library(dplyr)
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
   pr_auc(obs, VF:L)

--- a/man/pr_auc.Rd
+++ b/man/pr_auc.Rd
@@ -73,7 +73,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/pr_auc.Rd
+++ b/man/pr_auc.Rd
@@ -79,17 +79,33 @@ the "one" level is always the relevant result.
 }
 
 \examples{
-# Two class
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
 data("two_class_example")
+levels(two_class_example$truth)
+
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 pr_auc(two_class_example, truth, Class1)
 
-# Multiclass
-library(dplyr)
+# Multiclass example: obs variable is a four-level factor with the first
+# level set to be "VF" and thus obs == "VF" is the event of interest.
 data(hpc_cv)
+levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
+  pr_auc(obs, VF:L)
+
+# Change the first level of obs variable from "VF" to "M" and thus the
+# event of interest is now "obs" == "M".
+library(forcats)
+hpc_cv \%>\%
+  filter(Resample == "Fold01") \%>\%
+  mutate(obs = fct_relevel(obs, "M")) \%>\%
   pr_auc(obs, VF:L)
 
 # Groups are respected

--- a/man/pr_curve.Rd
+++ b/man/pr_curve.Rd
@@ -67,7 +67,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/pr_curve.Rd
+++ b/man/pr_curve.Rd
@@ -10,7 +10,7 @@ pr_curve(data, ...)
 
 \method{pr_curve}{data.frame}(data, truth, ..., na_rm = TRUE)
 
-\method{autoplot}{pr_df}(object, ...)
+autoplot.pr_df(object, ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}

--- a/man/pr_curve.Rd
+++ b/man/pr_curve.Rd
@@ -73,13 +73,20 @@ the "one" level is always the relevant result.
 }
 
 \examples{
-library(ggplot2)
-library(dplyr)
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
+data("two_class_example")
+levels(two_class_example$truth)
 
-# Two class - a tibble is returned
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 pr_curve(two_class_example, truth, Class1)
 
 # Visualize the curve using ggplot2 manually
+library(ggplot2)
+library(dplyr)
 pr_curve(two_class_example, truth, Class1) \%>\%
   ggplot(aes(x = recall, y = precision)) +
   geom_path() +

--- a/man/precision.Rd
+++ b/man/precision.Rd
@@ -70,7 +70,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/recall.Rd
+++ b/man/recall.Rd
@@ -70,7 +70,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -99,17 +99,33 @@ definition of multiclass AUC given by Provost and Domingos (2001).
 }
 
 \examples{
-# Two class
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
 data("two_class_example")
+levels(two_class_example$truth)
+
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 roc_auc(two_class_example, truth, Class1)
 
-# Multiclass
-library(dplyr)
+# Multiclass example: obs variable is a four-level factor with the first
+# level set to be "VF" and thus obs == "VF" is the event of interest.
 data(hpc_cv)
+levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
+  roc_auc(obs, VF:L)
+
+# Change the first level of obs variable from "VF" to "M" and thus the
+# event of interest is now "obs" == "M".
+library(forcats)
+hpc_cv \%>\%
+  filter(Resample == "Fold01") \%>\%
+  mutate(obs = fct_relevel(obs, "M")) \%>\%
   roc_auc(obs, VF:L)
 
 # Groups are respected

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -82,7 +82,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -117,6 +117,7 @@ data(hpc_cv)
 levels(hpc_cv$obs)
 
 # You can use the col1:colN tidyselect syntax
+library(dplyr)
 hpc_cv \%>\%
   filter(Resample == "Fold01") \%>\%
   roc_auc(obs, VF:L)

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -85,13 +85,20 @@ the "one" level is always the relevant result.
 }
 
 \examples{
-library(ggplot2)
-library(dplyr)
+# Two class example: truth variable is a two-level factor with the first
+# level set to be "Class1" and thus truth == "Class1" is the event of
+# interest (see "Relevant level" section above)
+data("two_class_example")
+levels(two_class_example$truth)
 
-# Two class - a tibbble is returned
+# Since "Class1" is the event of interest, the third argument of function
+# are the "Class1" probabilities stored in Class1 variable. A tibble is
+# returned.
 roc_curve(two_class_example, truth, Class1)
 
 # Visualize the curve using ggplot2 manually
+library(ggplot2)
+library(dplyr)
 roc_curve(two_class_example, truth, Class1) \%>\%
   ggplot(aes(x = 1 - specificity, y = sensitivity)) +
   geom_path() +

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -11,7 +11,7 @@ roc_curve(data, ...)
 \method{roc_curve}{data.frame}(data, truth, ..., options = list(),
   na_rm = TRUE)
 
-\method{autoplot}{roc_df}(object, ...)
+autoplot.roc_df(object, ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -79,7 +79,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/sens.Rd
+++ b/man/sens.Rd
@@ -69,7 +69,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/spec.Rd
+++ b/man/spec.Rd
@@ -68,7 +68,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/summary.conf_mat.Rd
+++ b/man/summary.conf_mat.Rd
@@ -42,7 +42,8 @@ In \code{yardstick}, the default is to use the \emph{first} level. To
 change this, a global option called \code{yardstick.event_first} is
 set to \code{TRUE} when the package is loaded. This can be changed
 to \code{FALSE} if the last level of the factor is considered the
-level of interest. For multiclass extensions involving one-vs-all
+level of interest by running: \code{options(yardstick.event_first = FALSE)}.
+For multiclass extensions involving one-vs-all
 comparisons (such as macro averaging), this option is ignored and
 the "one" level is always the relevant result.
 }

--- a/man/two_class_example.Rd
+++ b/man/two_class_example.Rd
@@ -19,5 +19,10 @@ class.
 \examples{
 data(two_class_example)
 str(two_class_example)
+
+# truth variable is a two-level factor with the first level set to be
+# "Class1" and thus truth == "Class1" is the event of interest for binary
+# classification.
+levels(hpc_cv$obs)
 }
 \keyword{datasets}


### PR DESCRIPTION
Hello, I teach an introductory Machine Learning course at Smith College along with my teaching assistant @czang97. We very much appreciate how useful many of the existing features of the yardstick package are in this class. At the moment, we are currently covering ROC curves + AUC.

We can definitely appreciate the long term goal alluded to in the warning message as soon as you startup yardstick: `For binary classification, the first factor level is assumed to be the event. Set the global option yardstick.event_first to FALSE to change this.` In particular how this allows you to generalize to both binary to multiclass classification metrics.

However, students were having a little difficulty understanding the `.Rd` help files for `roc_auc()` and `roc_curve()`, in particular the examples. As seen in #94 we don't seem to be alone.

In this PR I am proposing:
* Slightly more verbose examples for `roc_auc()`, `roc_curve()`, and other classification metrics related functions emphasizing the setting the first level of the factor requirement.
* Making explicit how to change the global option above by explicitly adding `options(yardstick.event_first = FALSE)` in the "Relevant level" section of all relevant help files. 

tl;dr I did this mostly by changing the template files in `man-roxygen/`. Many thanks.

For whatever it's worth, here is the output of my `sessioninfo::session_info()`:
```r
─ Session info ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value                       
 version  R version 3.5.3 (2019-03-11)
 os       macOS Mojave 10.14.3        
 system   x86_64, darwin15.6.0        
 ui       RStudio                     
 language (EN)                        
 collate  en_US.UTF-8                 
 ctype    en_US.UTF-8                 
 tz       America/New_York            
 date     2019-03-26                  

─ Packages ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 package     * version    date       lib source                             
 assertthat    0.2.1      2019-03-21 [1] CRAN (R 3.5.3)                     
 backports     1.1.3      2018-12-14 [1] CRAN (R 3.5.0)                     
 cli           1.1.0      2019-03-19 [1] CRAN (R 3.5.2)                     
 colorspace    1.4-1      2019-03-18 [1] CRAN (R 3.5.2)                     
 crayon        1.3.4      2019-02-01 [1] Github (gaborcsardi/crayon@74bee76)
 desc          1.2.0      2018-05-01 [1] CRAN (R 3.5.0)                     
 dplyr       * 0.8.0.1    2019-02-15 [1] CRAN (R 3.5.2)                     
 generics      0.0.2      2018-11-29 [1] CRAN (R 3.5.0)                     
 ggplot2     * 3.1.0      2018-10-25 [1] CRAN (R 3.5.0)                     
 glue          1.3.1      2019-03-12 [1] CRAN (R 3.5.2)                     
 gtable        0.3.0      2019-03-25 [1] CRAN (R 3.5.3)                     
 lazyeval      0.2.2      2019-03-15 [1] CRAN (R 3.5.2)                     
 magrittr      1.5        2014-11-22 [1] CRAN (R 3.5.0)                     
 munsell       0.5.0      2018-06-12 [1] CRAN (R 3.5.0)                     
 packrat       0.5.0      2018-11-14 [1] CRAN (R 3.5.0)                     
 pillar        1.3.1      2018-12-15 [1] CRAN (R 3.5.0)                     
 pkgconfig     2.0.2      2018-08-16 [1] CRAN (R 3.5.0)                     
 pkgload       1.0.2      2018-10-29 [1] CRAN (R 3.5.0)                     
 plyr          1.8.4      2016-06-08 [1] CRAN (R 3.5.0)                     
 pROC          1.14.0     2019-03-12 [1] CRAN (R 3.5.2)                     
 purrr         0.3.2      2019-03-15 [1] CRAN (R 3.5.2)                     
 R6            2.4.0      2019-02-14 [1] CRAN (R 3.5.2)                     
 Rcpp          1.0.1      2019-03-17 [1] CRAN (R 3.5.2)                     
 rlang         0.3.2      2019-03-21 [1] CRAN (R 3.5.3)                     
 rprojroot     1.3-2      2018-01-03 [1] CRAN (R 3.5.0)                     
 rstudioapi    0.10       2019-03-19 [1] CRAN (R 3.5.3)                     
 scales        1.0.0      2018-08-09 [1] CRAN (R 3.5.0)                     
 sessioninfo   1.1.1.9000 2019-03-26 [1] Github (r-lib/sessioninfo@dfb3ea8) 
 testthat      2.0.1      2018-10-13 [1] CRAN (R 3.5.0)                     
 tibble        2.1.1      2019-03-16 [1] CRAN (R 3.5.2)                     
 tidyselect    0.2.5      2018-10-11 [1] CRAN (R 3.5.0)                     
 withr         2.1.2      2018-03-15 [1] CRAN (R 3.5.0)                     
 yardstick   * 0.0.3.9000 2019-03-27 [1] local      
```