### PR TITLE
Fix for #104

### DIFF
--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -79,8 +79,7 @@ f_meas.table <- function (data, beta = 1, estimator = NULL, ...) {
 f_meas.matrix <- function(data, beta = 1, estimator = NULL, ...) {
 
   data <- as.table(data)
-  f_meas.table(data, estimator)
-
+  f_meas.table(data, estimator = estimator)
 }
 
 #' @export

--- a/tests/testthat/test-class-f_meas.R
+++ b/tests/testthat/test-class-f_meas.R
@@ -76,6 +76,18 @@ test_that("`NA` values propagate from multiclass `recall()`", {
 })
 
 # ------------------------------------------------------------------------------
+# Issue #104
+test_that("f_meas work when input is a matrix", {
+
+  data <- matrix(c(35, 22, 14, 118), nrow = 2)
+
+  expect_equal(
+    nrow(f_meas(data)),
+    1
+  )
+})
+
+# ------------------------------------------------------------------------------
 
 test_that("'micro' `NA` case is handled correctly", {
 


### PR DESCRIPTION
Correctly specify estimator argument in f_meas.table such that `f_meas()` works with matrices.

This closes #104 