### PR TITLE
Use tidy version of coords (xrobin/pROC#54)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
 Imports:
     dplyr,
     utils,
-    pROC,
+    pROC (>= 1.15.0),
     rlang,
     tidyselect,
     Rcpp,

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -166,18 +166,20 @@ roc_curve_binary <- function(truth, estimate, options) {
     res <- coords(
       curv,
       x = unique(c(-Inf, options$predictor, Inf)),
-      input = "threshold"
+      input = "threshold",
+      transpose = FALSE
     )
   }
   else {
     res <- coords(
       curv,
       x = unique(c(0, curv$specificities, 1)),
-      input = "specificity"
+      input = "specificity",
+      transpose = FALSE
     )
   }
 
-  res <- dplyr::as_tibble(t(res))
+  res <- dplyr::as_tibble(res)
 
   if (!inherits(curv, "smooth.roc")) {
     res <- dplyr::arrange(res, threshold)

--- a/tests/testthat/test-prob-roc.R
+++ b/tests/testthat/test-prob-roc.R
@@ -35,10 +35,10 @@ test_that('Two class', {
 
 test_that('ROC Curve', {
   library(pROC)
-  points <- coords(roc_curv, x = unique(c(-Inf, two_class_example$Class1, Inf)), input = "threshold")
-  points <- dplyr::as_tibble(t(points)) %>% dplyr::arrange(threshold) %>% dplyr::rename(.threshold = threshold)
-  s_points <- coords(smooth_curv, x = unique(c(0, smooth_curv$specificities, 1)), input = "specificity")
-  s_points <- dplyr::as_tibble(t(s_points)) %>% dplyr::arrange(specificity)
+  points <- coords(roc_curv, x = unique(c(-Inf, two_class_example$Class1, Inf)), input = "threshold", transpose = FALSE)
+  points <- dplyr::as_tibble(points) %>% dplyr::arrange(threshold) %>% dplyr::rename(.threshold = threshold)
+  s_points <- coords(smooth_curv, x = unique(c(0, smooth_curv$specificities, 1)), input = "specificity", transpose = FALSE)
+  s_points <- dplyr::as_tibble(s_points) %>% dplyr::arrange(specificity)
 
   expect_equal(
     as.data.frame(roc_curve(two_class_example, truth, Class1)),


### PR DESCRIPTION
An upcoming version of pROC (1.16) will feature backward incompatible changes in the coords function. In order to adhere to the principles of tidy datasets, the output will be transposed, and a data.frame returned instead of a matrix.

This PR sets the 'transpose' argument to 'coords' explicitly, and ensures proper operation with current (1.15) and future versions of pROC.