### PR TITLE
Fix ROC AUC direction and handling of levels with zero occurrences

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # yardstick (development version)
 
+* `roc_auc()` and `roc_curve()` now set `direction = "<"` when computing the
+  ROC curve using `pROC::roc()`. Results were being computed incorrectly with
+  `direction = "auto"` when most probability values were predicting the wrong
+  class (#123).
+
 * `metric_set()` now strips the package name when auto-labeling functions
   (@rorynolan, #151).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # yardstick (development version)
 
+* The `roc_auc()` Hand-Till multiclass estimator will now ignore levels in
+  `truth` that occur zero times in the actual data. With other methods of
+  multiclass averaging, this usually returns an `NA`, however, ignoring
+  levels in this manner is more consistent with implementations in the
+  HandTill2001 and pROC packages (#123).
+
 * `roc_auc()` and `roc_curve()` now set `direction = "<"` when computing the
   ROC curve using `pROC::roc()`. Results were being computed incorrectly with
   `direction = "auto"` when most probability values were predicting the wrong

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -3,14 +3,10 @@
 #' `roc_auc()` is a metric that computes the area under the ROC curve. See
 #' [roc_curve()] for the full curve.
 #'
-#' For most methods, `roc_auc()` defaults to allowing `pROC::roc()` control
-#' the direction of the computation, but allows you to control this by passing
-#' `options = list(direction = "<")` or any other allowed direction value.
-#' However, the Hand, Till (2001) method assumes that the individual AUCs are
-#' all above `0.5`, so if an AUC value below `0.5` is computed, then `1` is
-#' subtracted from it to get the correct result. When not using the Hand, Till
-#' method, pROC advises setting the `direction` when doing resampling so that
-#' the AUC values are not biased upwards.
+#' The underlying `direction` option in [pROC::roc()] is forced to
+#' `direction = "<"`. This computes the ROC curve assuming that the `estimate`
+#' values are the probability that the "event" occurred, which is what they
+#' are always assumed to be in yardstick.
 #'
 #' Generally, an ROC AUC value is between `0.5` and `1`, with `1` being a
 #' perfect prediction model. If your value is between `0` and `0.5`, then
@@ -36,7 +32,7 @@
 #'
 #' @param options A `list` of named options to pass to [pROC::roc()]
 #' such as `direction` or `smooth`. These options should not include `response`,
-#' `predictor`, `levels`, or `quiet`.
+#' `predictor`, `levels`, `quiet`, or `direction`.
 #'
 #' @param estimator One of `"binary"`, `"hand_till"`, `"macro"`, or
 #' `"macro_weighted"` to specify the type of averaging to be done. `"binary"`

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -183,7 +183,13 @@ roc_auc_binary <- function(truth, estimate, options) {
     return(NA_real_)
   }
 
-  args <- quos(response = truth, predictor = estimate, levels = lvl, quiet = TRUE)
+  args <- quos(
+    response = truth,
+    predictor = estimate,
+    levels = lvl,
+    quiet = TRUE,
+    direction = "<"
+  )
 
   pROC_auc <- eval_tidy(call2("auc", !!! args, !!! options, .ns = "pROC"))
 
@@ -250,20 +256,6 @@ roc_auc_subset <- function(lvl1, lvl2, truth, estimate, options) {
   estimate_subset <- estimate_lvl1[subset_idx]
 
   auc_val <- roc_auc_binary(truth_subset, estimate_subset, options)
-
-  # Early return if NA to avoid error in downstream if statement
-  if (is.na(auc_val)) {
-    return(auc_val)
-  }
-
-  # Hand Till 2001 uses an AUC calc that is always >0.5
-  # Eq 3 of https://link.springer.com/content/pdf/10.1023%2FA%3A1010920819831.pdf
-  # This means their multiclass auc metric is made up of these >0.5 AUCs.
-  # To be consistent, we force <0.5 AUC values to be 1-AUC which is the
-  # same value that HandTill would get.
-  if(auc_val < 0.5) {
-    auc_val <- 1 - auc_val
-  }
 
   auc_val
 }

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -31,7 +31,7 @@
 #' @inheritParams pr_auc
 #'
 #' @param options A `list` of named options to pass to [pROC::roc()]
-#' such as `direction` or `smooth`. These options should not include `response`,
+#' such as `smooth`. These options should not include `response`,
 #' `predictor`, `levels`, `quiet`, or `direction`.
 #'
 #' @param estimator One of `"binary"`, `"hand_till"`, `"macro"`, or

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -5,18 +5,6 @@
 #' curve of each class against the rest, using the a priori class distribution.
 #' This is equivalent to `roc_auc(estimator = "macro_weighted")`.
 #'
-#' Like the other ROC AUC metrics, `roc_aunp()` defaults to allowing
-#' `pROC::roc()` control the direction of the computation, but allows you to
-#' control this by passing `options = list(direction = "<")` or any other
-#' allowed direction value. pROC advises setting the `direction` when doing
-#' resampling so that the AUC values are not biased upwards.
-#'
-#' Generally, an ROC AUC value is between `0.5` and `1`, with `1` being a
-#' perfect prediction model. If your value is between `0` and `0.5`, then
-#' this implies that you have meaningful information in your model, but it
-#' is being applied incorrectly because doing the opposite of what the model
-#' predicts would result in an AUC `>0.5`.
-#'
 #' @family class probability metrics
 #' @templateVar metric_fn roc_aunp
 #' @template return
@@ -27,7 +15,7 @@
 #' a priori class distribution and is equivalent to
 #' `roc_auc(estimator = "macro_weighted")`.
 #'
-#' @inheritParams pr_auc
+#' @inheritParams roc_auc
 #'
 #' @param ... A set of unquoted column names or one or more `dplyr` selector
 #' functions to choose which variables contain the class probabilities. There
@@ -36,10 +24,6 @@
 #' @param estimate A matrix with as many
 #' columns as factor levels of `truth`. _It is assumed that these are in the
 #' same order as the levels of `truth`._
-#'
-#' @param options A `list` of named options to pass to [pROC::roc()]
-#' such as `direction` or `smooth`. These options should not include `response`,
-#' `predictor`, `levels`, or `quiet`.
 #'
 #' @references
 #'

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -5,18 +5,6 @@
 #' curve of each class against the rest, using the uniform class distribution.
 #' This is equivalent to `roc_auc(estimator = "macro")`.
 #'
-#' Like the other ROC AUC metrics, `roc_aunu()` defaults to allowing
-#' `pROC::roc()` control the direction of the computation, but allows you to
-#' control this by passing `options = list(direction = "<")` or any other
-#' allowed direction value. pROC advises setting the `direction` when doing
-#' resampling so that the AUC values are not biased upwards.
-#'
-#' Generally, an ROC AUC value is between `0.5` and `1`, with `1` being a
-#' perfect prediction model. If your value is between `0` and `0.5`, then
-#' this implies that you have meaningful information in your model, but it
-#' is being applied incorrectly because doing the opposite of what the model
-#' predicts would result in an AUC `>0.5`.
-#'
 #' @family class probability metrics
 #' @templateVar metric_fn roc_aunu
 #' @template return
@@ -27,7 +15,7 @@
 #' uniform class distribution and is equivalent to
 #' `roc_auc(estimator = "macro")`.
 #'
-#' @inheritParams pr_auc
+#' @inheritParams roc_auc
 #'
 #' @param ... A set of unquoted column names or one or more `dplyr` selector
 #' functions to choose which variables contain the class probabilities. There
@@ -36,10 +24,6 @@
 #' @param estimate A matrix with as many
 #' columns as factor levels of `truth`. _It is assumed that these are in the
 #' same order as the levels of `truth`._
-#'
-#' @param options A `list` of named options to pass to [pROC::roc()]
-#' such as `direction` or `smooth`. These options should not include `response`,
-#' `predictor`, `levels`, or `quiet`.
 #'
 #' @references
 #'

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -160,6 +160,7 @@ roc_curve_binary <- function(truth, estimate, options) {
   options$predictor <- estimate
   options$levels <- lvls
   options$quiet <- TRUE
+  options$direction <- "<"
 
   curv <- exec(pROC::roc, !!!options)
 

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -41,8 +41,8 @@ unquoted variable name. For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{object}{The \code{conf_mat} data frame returned from \code{conf_mat()}.}
 
-\item{type}{Type of plot desired, must be "mosaic" or "heatmap",
-defaults to "mosaic".}
+\item{type}{Type of plot desired, must be \code{"mosaic"} or \code{"heatmap"},
+defaults to \code{"mosaic"}.}
 }
 \value{
 \code{conf_mat()} produces an object with class \code{conf_mat}. This contains the

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -31,7 +31,7 @@ unquoted variable name.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
 such as \code{direction} or \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, or \code{quiet}.}
+\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -30,7 +30,7 @@ specified different ways but the primary method is to use an
 unquoted variable name.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{direction} or \code{smooth}. These options should not include \code{response},
+such as \code{smooth}. These options should not include \code{response},
 \code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -36,7 +36,7 @@ names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
 such as \code{direction} or \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, or \code{quiet}.}
+\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{estimator}{One of \code{"binary"}, \code{"hand_till"}, \code{"macro"}, or
 \code{"macro_weighted"} to specify the type of averaging to be done. \code{"binary"}
@@ -66,14 +66,10 @@ For \code{roc_auc_vec()}, a single \code{numeric} value (or \code{NA}).
 \code{\link[=roc_curve]{roc_curve()}} for the full curve.
 }
 \details{
-For most methods, \code{roc_auc()} defaults to allowing \code{pROC::roc()} control
-the direction of the computation, but allows you to control this by passing
-\code{options = list(direction = "<")} or any other allowed direction value.
-However, the Hand, Till (2001) method assumes that the individual AUCs are
-all above \code{0.5}, so if an AUC value below \code{0.5} is computed, then \code{1} is
-subtracted from it to get the correct result. When not using the Hand, Till
-method, pROC advises setting the \code{direction} when doing resampling so that
-the AUC values are not biased upwards.
+The underlying \code{direction} option in \code{\link[pROC:roc]{pROC::roc()}} is forced to
+\code{direction = "<"}. This computes the ROC curve assuming that the \code{estimate}
+values are the probability that the "event" occurred, which is what they
+are always assumed to be in yardstick.
 
 Generally, an ROC AUC value is between \code{0.5} and \code{1}, with \code{1} being a
 perfect prediction model. If your value is between \code{0} and \code{0.5}, then

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -35,7 +35,7 @@ this argument is passed by expression and supports
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{direction} or \code{smooth}. These options should not include \code{response},
+such as \code{smooth}. These options should not include \code{response},
 \code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{estimator}{One of \code{"binary"}, \code{"hand_till"}, \code{"macro"}, or

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -97,6 +97,9 @@ the "one" level is always the relevant result.
 The default multiclass method for computing \code{roc_auc()} is to use the
 method from Hand, Till, (2001). Unlike macro-averaging, this method is
 insensitive to class distributions like the binary ROC AUC case.
+Additionally, while other multiclass techniques will return \code{NA} if any
+levels in \code{truth} occur zero times in the actual data, the Hand-Till method
+will simply ignore those levels in the averaging calculation, with a warning.
 
 Macro and macro-weighted averaging are still provided, even though they are
 not the default. In fact, macro-weighted averaging corresponds to the same

--- a/man/roc_aunp.Rd
+++ b/man/roc_aunp.Rd
@@ -28,8 +28,8 @@ this argument is passed by expression and supports
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{direction} or \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, or \code{quiet}.}
+such as \code{smooth}. These options should not include \code{response},
+\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
@@ -51,19 +51,6 @@ For \code{roc_aunp_vec()}, a single \code{numeric} value (or \code{NA}).
 \code{roc_aunp()} is a multiclass metric that computes the area under the ROC
 curve of each class against the rest, using the a priori class distribution.
 This is equivalent to \code{roc_auc(estimator = "macro_weighted")}.
-}
-\details{
-Like the other ROC AUC metrics, \code{roc_aunp()} defaults to allowing
-\code{pROC::roc()} control the direction of the computation, but allows you to
-control this by passing \code{options = list(direction = "<")} or any other
-allowed direction value. pROC advises setting the \code{direction} when doing
-resampling so that the AUC values are not biased upwards.
-
-Generally, an ROC AUC value is between \code{0.5} and \code{1}, with \code{1} being a
-perfect prediction model. If your value is between \code{0} and \code{0.5}, then
-this implies that you have meaningful information in your model, but it
-is being applied incorrectly because doing the opposite of what the model
-predicts would result in an AUC \verb{>0.5}.
 }
 \section{Relevant Level}{
 

--- a/man/roc_aunu.Rd
+++ b/man/roc_aunu.Rd
@@ -28,8 +28,8 @@ this argument is passed by expression and supports
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{direction} or \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, or \code{quiet}.}
+such as \code{smooth}. These options should not include \code{response},
+\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
@@ -51,19 +51,6 @@ For \code{roc_aunu_vec()}, a single \code{numeric} value (or \code{NA}).
 \code{roc_aunu()} is a multiclass metric that computes the area under the ROC
 curve of each class against the rest, using the uniform class distribution.
 This is equivalent to \code{roc_auc(estimator = "macro")}.
-}
-\details{
-Like the other ROC AUC metrics, \code{roc_aunu()} defaults to allowing
-\code{pROC::roc()} control the direction of the computation, but allows you to
-control this by passing \code{options = list(direction = "<")} or any other
-allowed direction value. pROC advises setting the \code{direction} when doing
-resampling so that the AUC values are not biased upwards.
-
-Generally, an ROC AUC value is between \code{0.5} and \code{1}, with \code{1} being a
-perfect prediction model. If your value is between \code{0} and \code{0.5}, then
-this implies that you have meaningful information in your model, but it
-is being applied incorrectly because doing the opposite of what the model
-predicts would result in an AUC \verb{>0.5}.
 }
 \section{Relevant Level}{
 

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -29,7 +29,7 @@ names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
 such as \code{direction} or \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, or \code{quiet}.}
+\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -28,7 +28,7 @@ this argument is passed by expression and supports
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{direction} or \code{smooth}. These options should not include \code{response},
+such as \code{smooth}. These options should not include \code{response},
 \code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
 
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}

--- a/tests/testthat/test-prob-roc.R
+++ b/tests/testthat/test-prob-roc.R
@@ -41,6 +41,30 @@ test_that('Two class', {
   )
 })
 
+test_that("binary roc curve uses `direction = <`", {
+  # In yardstick we do events (or cases) as the first level
+  truth <- factor(c("control", "case", "case"), levels = c("case", "control"))
+
+  # Make really bad predictions
+  # This would force `direction = "auto"` to choose `>`,
+  # which would be incorrect. We are required to force `direction = <` for
+  # our purposes of having `estimate` match the event
+  estimate <- c(.8, .2, .1)
+
+  # pROC expects levels to be in the order of control, then event.
+  roc <- pROC::roc(
+    truth,
+    estimate,
+    levels = c("control", "case"),
+    direction = "<"
+  )
+
+  curve <- roc_curve_vec(truth, estimate)
+
+  expect_identical(curve$specificity, c(0, roc$specificities))
+  expect_identical(curve$sensitivity, c(1, roc$sensitivities))
+})
+
 test_that('ROC Curve', {
   library(pROC)
   points <- coords(roc_curv, x = unique(c(-Inf, two_class_example$Class1, Inf)), input = "threshold", transpose = FALSE)

--- a/tests/testthat/test-prob-roc.R
+++ b/tests/testthat/test-prob-roc.R
@@ -166,7 +166,32 @@ test_that("can calculate Hand Till when prob matrix column names are different f
 
 })
 
-test_that("`direction = <` is forced when binary AUCs are computed (#123)", {
+# ------------------------------------------------------------------------------
+
+test_that("binary roc auc uses `direction = <`", {
+  # In yardstick we do events (or cases) as the first level
+  truth <- factor(c("control", "case", "case"), levels = c("case", "control"))
+
+  # Make really bad predictions
+  # This would force `direction = "auto"` to choose `>`,
+  # which would be incorrect. We are required to force `direction = <` for
+  # our purposes of having `estimate` match the event
+  estimate <- c(.8, .2, .1)
+
+  # pROC() expects levels to be in the order of control, then event.
+  auc <- pROC::auc(
+    truth,
+    estimate,
+    levels = c("control", "case"),
+    direction = "<"
+  )
+
+  auc <- as.numeric(auc)
+
+  expect_identical(roc_auc_vec(truth, estimate), auc)
+})
+
+test_that("`direction = <` is forced when individual binary AUCs are computed (#123)", {
   truth <- factor(
     c(
       "c", "c", "c", "d", "d", "a", "d", "c", "a",


### PR DESCRIPTION
Closes #123 

This PR fixes two issues:

---

The first was a long standing bug, which has been around since day 1 when `pr_auc()` was implemented on top of `pROC::auc()` (and through it, `pROC::roc()`). It affected binary pr-auc and the multiclass case.

`pROC::roc()` has an argument called `direction = "auto"` that "automatically" decides if binary class probabilities like `0.8` are to be interpreted as "the probability that this observation is a control" or "the probability that this observation is an event". It generally chooses the right thing, _however_ it "decides" by computing the median probability of each group (case / control) and takes the probability that is higher. This is not always correct, especially when resampling or computing a metric that calls the binary version of pr-auc multiple times (like macro averaging or hand-till).

In yardstick, we always assume that `estimate` is "the probability that this observation is an event". We then let the `yardstick.event_first` option tell us which level is the actual event. Because of this, we can always set `direction = "<"`, which aligns with this interpretation of `estimate`. Doing that fixes any ambiguity.

This was also fixed for `roc_curve()`, which also used `pROC::roc()` to compute the curve.

---

The second issue was a bit subjective. Normally with averaging methods like macro/micro averaging, when `truth` has a level that has zero occurrences in the actual `truth` vector, we return `NA` with a warning. However, the HandTill2001 and pROC packages both proceed by ignoring those levels, with a warning. We now do this as well.