### PR TITLE
added an `as_tibble()` method for `metric_set`s

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9000

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 S3method(accuracy,data.frame)
 S3method(accuracy,matrix)
 S3method(accuracy,table)
+S3method(as_tibble,metric_set)
 S3method(average_precision,data.frame)
 S3method(bal_accuracy,data.frame)
 S3method(bal_accuracy,matrix)

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   on top of the shaded polygon, resulting in a sharper look for the
   line itself (#192, @eddjberry).
 
+* Added a `as_tibble()` method for `metric_set` objects.
+
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders
   here](https://github.com/tidymodels/yardstick/issues/204) (#204).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,9 @@
   on top of the shaded polygon, resulting in a sharper look for the
   line itself (#192, @eddjberry).
 
-* Added a `as_tibble()` method for `metric_set` objects (#186).
+* Added an `as_tibble()` method for `metric_set` objects. Printing a
+  `metric_set` now uses this to print out a tibble rather than a data frame
+  (#186).
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders
   here](https://github.com/tidymodels/yardstick/issues/204) (#204).

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
   on top of the shaded polygon, resulting in a sharper look for the
   line itself (#192, @eddjberry).
 
-* Added a `as_tibble()` method for `metric_set` objects.
+* Added a `as_tibble()` method for `metric_set` objects (#186).
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders
   here](https://github.com/tidymodels/yardstick/issues/204) (#204).

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -287,6 +287,14 @@ metric_set <- function(...) {
 
 #' @export
 print.metric_set <- function(x, ...) {
+  info <- as_tibble(x)
+  print(info)
+  invisible(x)
+}
+
+#' @importFrom dplyr as_tibble
+#' @export
+as_tibble.metric_set <- function(x, ...) {
   metrics <- attributes(x)$metrics
   names <- names(metrics)
   metrics <- unname(metrics)
@@ -294,15 +302,11 @@ print.metric_set <- function(x, ...) {
   classes <- map_chr(metrics, class1)
   directions <- map_chr(metrics, get_metric_fn_direction)
 
-  info <- data.frame(
+  dplyr::tibble(
     metric = names,
     class = classes,
     direction = directions
   )
-
-  print(info)
-
-  invisible(x)
 }
 
 map_chr <- function(x, f, ...) {

--- a/tests/testthat/test-print-metric_set.txt
+++ b/tests/testthat/test-print-metric_set.txt
@@ -1,7 +1,9 @@
 > multi_metric <- metric_set(rmse, rsq, ccc)
 > print(multi_metric)
-  metric          class direction
-1   rmse numeric_metric  minimize
-2    rsq numeric_metric  maximize
-3    ccc numeric_metric  maximize
+# A tibble: 3 x 3
+  metric class          direction
+  <chr>  <chr>          <chr>    
+1 rmse   numeric_metric minimize 
+2 rsq    numeric_metric maximize 
+3 ccc    numeric_metric maximize 
 

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -221,7 +221,7 @@ test_that("print metric_set works", {
   })
 })
 
-test_that("metric_set can be coersed to a tibble", {
+test_that("metric_set can be coerced to a tibble", {
   x <- metric_set(roc_auc, pr_auc, accuracy)
   expect_s3_class(as_tibble(x), "tbl_df")
 })

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -221,6 +221,11 @@ test_that("print metric_set works", {
   })
 })
 
+test_that("metric_set can be coersed to a tibble", {
+  x <- metric_set(roc_auc, pr_auc, accuracy)
+  expect_s3_class(as_tibble(x), "tbl_df")
+})
+
 test_that("`metric_set()` errors contain env name for unknown functions (#128)", {
   foobar <- function() {}
 


### PR DESCRIPTION
Added an `as_tibble()` method for `metric_set` objects and used it in the print method (instead of a data.frame). This is for #186. 