### PR TITLE
Use `sens_binary()` rather than `recall_binary()` where appropriate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # yardstick (development version)
 
+* When `sens()` is undefined when computing `ppv()`, `npv()`, `j_index()`, or 
+  `bal_accuracy()`, a sensitivity warning is now correctly thrown, rather than
+  a recall warning (#101).
+
 * The `autoplot()` method for gain curves now plots the curve line
   on top of the shaded polygon, resulting in a sharper look for the
   line itself (#192, @eddjberry).

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -112,8 +112,7 @@ bal_accuracy_table_impl <- function(data, estimator, event_level) {
 }
 
 bal_accuracy_binary <- function(data, event_level) {
-  # (sens + spec) / 2
-  ( recall_binary(data, event_level) + spec_binary(data, event_level) ) / 2
+  ( sens_binary(data, event_level) + spec_binary(data, event_level) ) / 2
 }
 
 # Urbanowicz 2015 ExSTraCS 2.0 description and evaluation of a scalable learning.pdf

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -132,8 +132,7 @@ j_index_table_impl <- function(data, estimator, event_level) {
 }
 
 j_index_binary <- function(data, event_level) {
-  # sens + spec - 1
-  recall_binary(data, event_level) + spec_binary(data, event_level) - 1
+  sens_binary(data, event_level) + spec_binary(data, event_level) - 1
 }
 
 j_index_multiclass <- function(data, estimator) {

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -141,8 +141,7 @@ npv_binary <- function(data, event_level, prevalence = NULL) {
   if (is.null(prevalence))
     prevalence <- sum(data[, positive]) / sum(data)
 
-  # recall = sens
-  sens <- recall_binary(data, event_level)
+  sens <- sens_binary(data, event_level)
   spec <- spec_binary(data, event_level)
   (spec * (1 - prevalence)) / (((1 - sens) * prevalence) + ((spec) * (1 - prevalence)))
 }

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -157,8 +157,7 @@ ppv_binary <- function(data, event_level, prevalence = NULL) {
     prevalence <- sum(data[, positive]) / sum(data)
   }
 
-  # sens = recall
-  sens <- recall_binary(data, event_level)
+  sens <- sens_binary(data, event_level)
   spec <- spec_binary(data, event_level)
   (sens * prevalence) / ((sens * prevalence) + ((1 - spec) * (1 - prevalence)))
 }

--- a/tests/testthat/test-class-ppv-warning-binary.txt
+++ b/tests/testthat/test-class-ppv-warning-binary.txt
@@ -1,0 +1,3 @@
+While computing binary `sens()`, no true events were detected (i.e. `true_positive + false_negative = 0`). 
+Sensitivity is undefined in this case, and `NA` will be returned.
+Note that 1 predicted event(s) actually occured for the problematic event level, 'a'.

--- a/tests/testthat/test-class-ppv.R
+++ b/tests/testthat/test-class-ppv.R
@@ -79,3 +79,22 @@ test_that('Three class', {
     )
   )
 })
+
+# ------------------------------------------------------------------------------
+
+test_that("Binary `ppv()` returns `NA` with a warning when `sens()` is undefined (tp + fn = 0) (#101)", {
+  levels <- c("a", "b")
+  truth    <- factor(c("b", "b"), levels = levels)
+  estimate <- factor(c("a", "b"), levels = levels)
+
+  expect_warning(
+    expect_equal(
+      ppv_vec(truth, estimate),
+      NA_real_
+    )
+  )
+
+  cnd <- rlang::catch_cnd(ppv_vec(truth, estimate))
+  expect_known_output(cat(cnd$message), test_path("test-class-ppv-warning-binary.txt"), print = TRUE)
+  expect_s3_class(cnd, "yardstick_warning_sens_undefined_binary")
+})


### PR DESCRIPTION
Closes #101 
Follow up to #118 where this should have been done originally

Any time we compute a sens + spec type of metric, we used to use `recall_binary()` because it was the same as computing sens. In #118 we added `sens_binary()` so we could throw sens specific warnings as needed, but our usage of `recall_binary()` wasn't updated to use `sens_binary()` instead. This PR fixes that.