### PR TITLE
Drop usage of kableExtra to avoid `collapse_rows()` issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Suggests:
     covr,
     crayon,
     ggplot2,
-    kableExtra,
     knitr,
     purrr,
     rmarkdown,

--- a/vignettes/metric-types.Rmd
+++ b/vignettes/metric-types.Rmd
@@ -94,7 +94,6 @@ Below is a table of all of the metrics available in `yardstick`, grouped
 by type.
 
 ```{r, echo=FALSE, warning=FALSE, message=FALSE, results='asis'}
-library(kableExtra)
 library(knitr)
 library(dplyr)
 
@@ -113,9 +112,6 @@ all_metrics <- bind_rows(
   tibble(type = "numeric", metric = get_metrics(fns, "numeric_metric"))
 )
 
-all_metrics %>%
-  knitr::kable(format = "html") %>%
-  kable_styling(full_width = FALSE) %>%
-  collapse_rows(columns = 1)
+kable(all_metrics, format = "html")
 ```
 


### PR DESCRIPTION
At the cost of a slightly uglier table