### PR TITLE
Allow custom table names in `autoplot.conf_mat()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,10 @@
 * The `autoplot()` method for gain curves now plots the curve line
   on top of the shaded polygon, resulting in a sharper look for the
   line itself (#192, @eddjberry).
+  
+* The `autoplot()` methods for `conf_mat` now respect user-defined dimension
+  names added through `conf_mat(dnn = )` or from converting a table with
+  dimension names to a `conf_mat` (#191).
 
 * Added an `as_tibble()` method for `metric_set` objects. Printing a
   `metric_set` now uses this to print out a tibble rather than a data frame

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -364,6 +364,13 @@ space_y_fun <- function(data, id, x_data) {
 cm_mosaic <- function(x) {
   `%+%` <- ggplot2::`%+%`
 
+  dimension_labels <- names(dimnames(x$table))
+  if (is.null(dimension_labels)) {
+    dimension_labels <- c("Prediction", "Truth")
+  }
+  y_lab <- dimension_labels[[1]]
+  x_lab <- dimension_labels[[2]]
+
   cm_zero <- (as.numeric(x$table == 0) / 2) + x$table
 
   x_data <- space_fun(colSums(cm_zero), 200)
@@ -397,8 +404,8 @@ cm_mosaic <- function(x) {
       labels = tick_labels
     ) %+%
     ggplot2::labs(
-      y = "Predicted",
-      x = "Truth"
+      y = y_lab,
+      x = x_lab
     ) %+%
     ggplot2::theme(panel.background = ggplot2::element_blank())
 }

--- a/tests/testthat/test_autoplot.R
+++ b/tests/testthat/test_autoplot.R
@@ -360,7 +360,7 @@ test_that("Confusion Matrix - multi class - heatmap", {
   expect_equal(rlang::expr_label(.plot$mapping[["fill"]]), "`~Freq`")
 })
 
-test_that("Confusion Matrix - mosaic - non-standard labels (#157)", {
+test_that("Confusion Matrix - heatmap - non-standard labels (#157)", {
   res <- hpc_cv %>%
     filter(Resample == "Fold01") %>%
     conf_mat(obs, pred, dnn = c("Pred", "True"))
@@ -370,6 +370,21 @@ test_that("Confusion Matrix - mosaic - non-standard labels (#157)", {
   # Overridden with default labels
   expect_identical(.plot$labels$x, "Truth")
   expect_identical(.plot$labels$y, "Prediction")
+})
+
+test_that("Confusion Matrix - mosaic - can use non-standard labels (#191)", {
+  df <- filter(hpc_cv, Resample == "Fold01")
+
+  res1 <- conf_mat(df, obs, pred, dnn = c("Pred", "True"))
+  expect_error(p1 <- autoplot(res1, type = "mosaic"), NA)
+  expect_identical(p1$labels$x, "True")
+  expect_identical(p1$labels$y, "Pred")
+
+  # Defaults are used when there are no names
+  res2 <- conf_mat(df, obs, pred, dnn = NULL)
+  expect_error(p2 <- autoplot(res2, type = "mosaic"), NA)
+  expect_identical(p2$labels$x, "Truth")
+  expect_identical(p2$labels$y, "Prediction")
 })
 
 test_that("Confusion Matrix - two class - mosaic", {

--- a/tests/testthat/test_autoplot.R
+++ b/tests/testthat/test_autoplot.R
@@ -360,16 +360,19 @@ test_that("Confusion Matrix - multi class - heatmap", {
   expect_equal(rlang::expr_label(.plot$mapping[["fill"]]), "`~Freq`")
 })
 
-test_that("Confusion Matrix - heatmap - non-standard labels (#157)", {
-  res <- hpc_cv %>%
-    filter(Resample == "Fold01") %>%
-    conf_mat(obs, pred, dnn = c("Pred", "True"))
+test_that("Confusion Matrix - heatmap - can use non-standard labels (#157, #191)", {
+  df <- filter(hpc_cv, Resample == "Fold01")
 
-  expect_error(.plot <- autoplot(res, type = "heatmap"), NA)
+  res1 <- conf_mat(df, obs, pred, dnn = c("Pred", "True"))
+  expect_error(p1 <- autoplot(res1, type = "heatmap"), NA)
+  expect_identical(p1$labels$x, "True")
+  expect_identical(p1$labels$y, "Pred")
 
-  # Overridden with default labels
-  expect_identical(.plot$labels$x, "Truth")
-  expect_identical(.plot$labels$y, "Prediction")
+  # Defaults are used when there are no names
+  res2 <- conf_mat(df, obs, pred, dnn = NULL)
+  expect_error(p2 <- autoplot(res2, type = "heatmap"), NA)
+  expect_identical(p2$labels$x, "Truth")
+  expect_identical(p2$labels$y, "Prediction")
 })
 
 test_that("Confusion Matrix - mosaic - can use non-standard labels (#191)", {


### PR DESCRIPTION
Closes #191 
Better fix for #157 

Not sure why we didn't do this to start with in #170 

``` r
foo <- factor(sample(1:5, 100, replace = T))
bar <- factor(sample(1:5, 100, replace = T))
df <- data.frame(foo, bar)
conf <- yardstick::conf_mat(df, foo, bar, dnn = c("custom", "names"))

ggplot2::autoplot(conf, type = "mosaic")
```

![](https://i.imgur.com/ou76Tx6.png)

``` r
ggplot2::autoplot(conf, type = "heatmap")
```

![](https://i.imgur.com/cPq8ybC.png)

<sup>Created on 2021-03-25 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>