### PR TITLE
Remove usage of `dplyr::do()` in favor of `dplyr::summarise()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ BugReports: https://github.com/tidymodels/yardstick/issues
 Depends:
     R (>= 2.10)
 Imports:
-    dplyr (>= 0.8.5),
+    dplyr (>= 1.0.0),
     generics,
     pROC (>= 1.15.0),
     rlang (>= 0.4.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * `roc_curve()` now throws a more informative error if `truth` doesn't have any
   control or event observations.
   
+* dplyr 1.0.0 is now required. This allowed us to remove multiple usages of
+  `dplyr::do()` in favor of `dplyr::summarise()`, which can now return packed
+  data frame columns and multiple rows per group.
+  
 * Internal upkeep has been done to move from `rlang::warn(.subclass = )` to
   `rlang::warn(class = )`, since the `.subclass` argument has been deprecated
   (#225).

--- a/R/misc.R
+++ b/R/misc.R
@@ -69,3 +69,28 @@ as_factor_from_class_pred <- function(x) {
   }
   probably::as.factor(x)
 }
+
+# ------------------------------------------------------------------------------
+
+curve_finalize <- function(result, data, class, grouped_class) {
+  # Packed `.estimate` curve data frame
+  out <- dplyr::pull(result, ".estimate")
+
+  if (!dplyr::is_grouped_df(data)) {
+    class(out) <- c(class, class(out))
+    return(out)
+  }
+
+  group_syms <- dplyr::groups(data)
+
+  # Poor-man's `tidyr::unpack()`
+  groups <- dplyr::select(result, !!!group_syms)
+  out <- dplyr::bind_cols(groups, out)
+
+  # Curve functions always return a result grouped by original groups
+  out <- dplyr::group_by(out, !!!group_syms)
+
+  class(out) <- c(grouped_class, class, class(out))
+
+  out
+}

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -107,31 +107,18 @@ gain_curve.data.frame <- function(data,
                                   na_rm = TRUE,
                                   event_level = yardstick_event_level()) {
   estimate <- dots_to_estimate(data, !!! enquos(...))
-  truth <- enquo(truth)
 
-  validate_not_missing(truth, "truth")
-
-  # Explicit handling of length 1 character vectors as column names
-  truth <- handle_chr_names(truth, colnames(data))
-
-  res <- dplyr::do(
-    data,
-    gain_curve_vec(
-      truth = rlang::eval_tidy(truth, data = .),
-      estimate = rlang::eval_tidy(estimate, data = .),
-      na_rm = na_rm,
-      event_level = event_level
-    )
+  result <- metric_summarizer(
+    metric_nm = "gain_curve",
+    metric_fn = gain_curve_vec,
+    data = data,
+    truth = !!enquo(truth),
+    estimate = !!estimate,
+    na_rm = na_rm,
+    event_level = event_level
   )
 
-  if (dplyr::is_grouped_df(res)) {
-    class(res) <- c("grouped_gain_df", "gain_df", class(res))
-  }
-  else {
-    class(res) <- c("gain_df", class(res))
-  }
-
-  res
+  curve_finalize(result, data, "gain_df", "grouped_gain_df")
 }
 
 # dont export gain_curve_vec / lift_curve_vec

--- a/R/prob-lift_curve.R
+++ b/R/prob-lift_curve.R
@@ -92,31 +92,18 @@ lift_curve.data.frame <- function(data,
                                   na_rm = TRUE,
                                   event_level = yardstick_event_level()) {
   estimate <- dots_to_estimate(data, !!! enquos(...))
-  truth <- enquo(truth)
 
-  validate_not_missing(truth, "truth")
-
-  # Explicit handling of length 1 character vectors as column names
-  truth <- handle_chr_names(truth, colnames(data))
-
-  res <- dplyr::do(
-    data,
-    lift_curve_vec(
-      truth = rlang::eval_tidy(truth, data = .),
-      estimate = rlang::eval_tidy(estimate, data = .),
-      na_rm = na_rm,
-      event_level = event_level
-    )
+  result <- metric_summarizer(
+    metric_nm = "lift_curve",
+    metric_fn = lift_curve_vec,
+    data = data,
+    truth = !!enquo(truth),
+    estimate = !!estimate,
+    na_rm = na_rm,
+    event_level = event_level
   )
 
-  if (dplyr::is_grouped_df(res)) {
-    class(res) <- c("grouped_lift_df", "lift_df", class(res))
-  }
-  else {
-    class(res) <- c("lift_df", class(res))
-  }
-
-  res
+  curve_finalize(result, data, "lift_df", "grouped_lift_df")
 }
 
 lift_curve_vec <- function(truth,

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -72,31 +72,18 @@ pr_curve.data.frame <- function(data,
                                 na_rm = TRUE,
                                 event_level = yardstick_event_level()) {
   estimate <- dots_to_estimate(data, !!! enquos(...))
-  truth <- enquo(truth)
 
-  validate_not_missing(truth, "truth")
-
-  # Explicit handling of length 1 character vectors as column names
-  truth <- handle_chr_names(truth, colnames(data))
-
-  res <- dplyr::do(
-    data,
-    pr_curve_vec(
-      truth = rlang::eval_tidy(truth, data = .),
-      estimate = rlang::eval_tidy(estimate, data = .),
-      na_rm = na_rm,
-      event_level = event_level
-    )
+  result <- metric_summarizer(
+    metric_nm = "pr_curve",
+    metric_fn = pr_curve_vec,
+    data = data,
+    truth = !!enquo(truth),
+    estimate = !!estimate,
+    na_rm = na_rm,
+    event_level = event_level
   )
 
-  if (dplyr::is_grouped_df(res)) {
-    class(res) <- c("grouped_pr_df", "pr_df", class(res))
-  }
-  else {
-    class(res) <- c("pr_df", class(res))
-  }
-
-  res
+  curve_finalize(result, data, "pr_df", "grouped_pr_df")
 }
 
 # Undecided of whether to export this or not

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -85,34 +85,19 @@ roc_curve.data.frame <- function (data,
                                   na_rm = TRUE,
                                   event_level = yardstick_event_level()) {
   estimate <- dots_to_estimate(data, !!! enquos(...))
-  truth <- enquo(truth)
 
-  validate_not_missing(truth, "truth")
-
-  # Explicit handling of length 1 character vectors as column names
-  nms <- colnames(data)
-  truth <- handle_chr_names(truth, nms)
-  estimate <- handle_chr_names(estimate, nms)
-
-  res <- dplyr::do(
-    data,
-    roc_curve_vec(
-      truth = rlang::eval_tidy(truth, data = .),
-      estimate = rlang::eval_tidy(estimate, data = .),
-      na_rm = na_rm,
-      event_level = event_level,
-      !!! list(options = options)
-    )
+  result <- metric_summarizer(
+    metric_nm = "roc_curve",
+    metric_fn = roc_curve_vec,
+    data = data,
+    truth = !!enquo(truth),
+    estimate = !!estimate,
+    na_rm = na_rm,
+    event_level = event_level,
+    metric_fn_options = list(options = options)
   )
 
-  if (dplyr::is_grouped_df(res)) {
-    class(res) <- c("grouped_roc_df", "roc_df", class(res))
-  }
-  else {
-    class(res) <- c("roc_df", class(res))
-  }
-
-  res
+  curve_finalize(result, data, "roc_df", "grouped_roc_df")
 }
 
 roc_curve_vec <- function(truth,

--- a/tests/testthat/test-prob-roc.R
+++ b/tests/testthat/test-prob-roc.R
@@ -410,7 +410,7 @@ test_that("roc_curve() - error is thrown when missing events", {
   no_event <- dplyr::filter(two_class_example, truth == "Class2")
 
   expect_error(
-    roc_curve(no_event, truth, Class1)[[".estimate"]],
+    roc_curve_vec(no_event$truth, no_event$Class1)[[".estimate"]],
     "No event observations were detected in `truth` with event level 'Class1'.",
     class = "yardstick_error_roc_truth_no_event"
   )
@@ -420,7 +420,7 @@ test_that("roc_curve() - error is thrown when missing controls", {
   no_control <- dplyr::filter(two_class_example, truth == "Class1")
 
   expect_error(
-    roc_curve(no_control, truth, Class1)[[".estimate"]],
+    roc_curve_vec(no_control$truth, no_control$Class1)[[".estimate"]],
     "No control observations were detected in `truth` with control level 'Class2'.",
     class = "yardstick_error_roc_truth_no_control"
   )
@@ -430,7 +430,7 @@ test_that("roc_curve() - multiclass one-vs-all approach results in error", {
   no_event <- dplyr::filter(hpc_cv, Resample == "Fold01", obs == "VF")
 
   expect_error(
-    roc_curve(no_event, obs, VF:L)[[".estimate"]],
+    roc_curve_vec(no_event$obs, as.matrix(dplyr::select(no_event, VF:L)))[[".estimate"]],
     "No control observations were detected in `truth` with control level '..other'",
     class = "yardstick_error_roc_truth_no_control"
   )


### PR DESCRIPTION
Powered by new dplyr 1.0.0 features, i.e. multiple rows returned in a single summarise call, and packed data frame columns.

This is great because now even the curve functions go through the standard `metric_summarizer()` machinery.