### PR TITLE
no longer using dplyr_error

### DIFF
--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -10,24 +10,21 @@ test_that('bad args', {
 test_that("`truth` should be factor", {
   expect_error(
     sens(pathology, 1, factor("A")),
-    "`truth` should be a factor",
-    class = "dplyr_error"
+    "`truth` should be a factor"
   )
 })
 
 test_that("At least 2 levels in truth", {
   expect_error(
     sens(pathology, factor("A"), factor("A")),
-    "`estimator` is binary, only two class `truth` factors are allowed",
-    class = "dplyr_error"
+    "`estimator` is binary, only two class `truth` factors are allowed"
   )
 })
 
 test_that("Single character values are caught with correct errors", {
   expect_error(
     sens(pathology, "a", factor("A")),
-    "`truth` should be a factor",
-    class = "dplyr_error"
+    "`truth` should be a factor"
   )
 })
 
@@ -35,8 +32,7 @@ test_that("Bad unquoted input is caught", {
   bad <- rlang::expr(c("a", "b"))
   expect_error(
     sens(pathology, !! bad, factor("A")),
-    "`truth` should be a factor",
-    class = "dplyr_error"
+    "`truth` should be a factor"
   )
 })
 
@@ -45,43 +41,37 @@ test_that("Bad unquoted input is caught", {
 test_that("Non-allowed estimator", {
   expect_error(
     sens(pathology, pathology, scan, estimator = "blah"),
-    "`estimator` must be one of",
-    class = "dplyr_error"
+    "`estimator` must be one of"
   )
 })
 
 test_that("Bad estimator + truth combination", {
   expect_error(
     sens(hpc_cv, obs, pred, estimator = "binary"),
-    "`estimator` is binary",
-    class = "dplyr_error"
+    "`estimator` is binary"
   )
 })
 
 test_that("Bad estimator type", {
   expect_error(
     sens(hpc_cv, obs, pred, estimator = 1),
-    "`estimator` must be a character",
-    class = "dplyr_error"
+    "`estimator` must be a character"
   )
 
   expect_error(
     sens(hpc_cv, obs, pred, estimator = c("1", "2")),
-    "`estimator` must be length 1",
-    class = "dplyr_error"
+    "`estimator` must be length 1"
   )
 })
 
 test_that("Numeric matrix in numeric metric", {
   expect_error(
     rmse(solubility_test, matrix(1:5), prediction),
-    "`truth` should be a numeric vector",
-    class = "dplyr_error"
+    "`truth` should be a numeric vector"
   )
   expect_error(
     rmse(solubility_test, solubility, matrix(1:5)),
-    "`estimate` should be a numeric vector",
-    class = "dplyr_error"
+    "`estimate` should be a numeric vector"
   )
 })
 
@@ -94,24 +84,21 @@ test_that("Factors with non identical levels", {
 
   expect_error(
     sens(df, x, y),
-    "`truth` and `estimate` levels must be equivalent.",
-    class = "dplyr_error"
+    "`truth` and `estimate` levels must be equivalent."
   )
 })
 
 test_that("Multiple estimate columns for a binary metric", {
   expect_error(
     roc_auc(two_class_example, truth, Class1:Class2),
-    "You are using a `binary` metric",
-    class = "dplyr_error"
+    "You are using a `binary` metric"
   )
 })
 
 test_that("1 estimate column for a multiclass metric", {
   expect_error(
     roc_auc(hpc_cv, obs, VF),
-    "The number of levels in `truth`",
-    class = "dplyr_error"
+    "The number of levels in `truth`"
   )
 })
 

--- a/tests/testthat/test-numeric.R
+++ b/tests/testthat/test-numeric.R
@@ -220,14 +220,12 @@ test_that('Huber Loss', {
 
   expect_error(
     huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = -1),
-    "`delta` must be a positive value.",
-    class = "dplyr_error"
+    "`delta` must be a positive value."
   )
 
   expect_error(
     huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1,2)),
-    "`delta` must be a single numeric value.",
-    class = "dplyr_error"
+    "`delta` must be a single numeric value."
   )
 
 })
@@ -253,14 +251,12 @@ test_that('Pseudo-Huber Loss', {
 
   expect_error(
     huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = -1),
-    "`delta` must be a positive value.",
-    class = "dplyr_error"
+    "`delta` must be a positive value."
   )
 
   expect_error(
     huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1,2)),
-    "`delta` must be a single numeric value.",
-    class = "dplyr_error"
+    "`delta` must be a single numeric value."
   )
 })
 

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -12,8 +12,7 @@ test_that("AUNP is equivalent to macro_weighted estimator", {
 test_that("AUNP errors on binary case", {
   expect_error(
     roc_aunp(two_class_example, truth, Class1),
-    "The number of levels in",
-    class = "dplyr_error"
+    "The number of levels in"
   )
 })
 

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -12,8 +12,7 @@ test_that("AUNU is equivalent to macro estimator", {
 test_that("AUNU errors on binary case", {
   expect_error(
     roc_aunu(two_class_example, truth, Class1),
-    "The number of levels in",
-    class = "dplyr_error"
+    "The number of levels in"
   )
 })
 


### PR DESCRIPTION
dplyr 1.0.8 will stop using classed errors of type "dplyr_error". 

This will also fail because of https://github.com/r-lib/testthat/issues/1493, for example: 

````
Failure (test-error-handling.R:11:3): `truth` should be factor
`sens(pathology, 1, factor("A"))` threw an error with unexpected message.
Expected match: "`truth` should be a factor"
Actual message: "Problem while computing `.estimate = metric_fn(truth = 1, estimate = factor(\"A\"), na_rm = na_rm, event_level = \"first\")`."
Backtrace:
  1. testthat::expect_error(sens(pathology, 1, factor("A")), "`truth` should be a factor")
       at test-error-handling.R:11:2
 17. yardstick metric_fn(truth = 1, estimate = factor("A"), na_rm = na_rm, event_level = "first")
 18. yardstick::metric_vec_template(...)
       at yardstick/R/class-sens.R:147:2
 19. yardstick::validate_truth_estimate_checks(...)
       at yardstick/R/template.R:174:2
 20. yardstick::validate_class(truth, "truth", cls[1])
       at yardstick/R/validation.R:201:2
````

Perhaps it's a good signal to start using snapshot tests here too. 
