### PR TITLE
Add case weight support for `gain_capture()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
   
   * Probability:
     * classification_cost
+    * gain_capture
     * gain_curve
     * lift_curve
     * mn_log_loss

--- a/R/prob-helpers.R
+++ b/R/prob-helpers.R
@@ -149,6 +149,21 @@ one_vs_all_with_level <- function(metric_fn, truth, estimate, ...) {
 }
 
 # TODO: Remove me when all one-vs-all users support case weights
+one_vs_all_case_weights <- function(metric_fn,
+                                    truth,
+                                    estimate,
+                                    case_weights,
+                                    ...) {
+  one_vs_all_impl(
+    metric_fn = metric_fn,
+    truth = truth,
+    estimate = estimate,
+    case_weights = case_weights,
+    ...
+  )
+}
+
+# TODO: Remove me when all one-vs-all users support case weights
 one_vs_all_with_level_case_weights <- function(metric_fn,
                                                truth,
                                                estimate,

--- a/man/gain_capture.Rd
+++ b/man/gain_capture.Rd
@@ -14,7 +14,8 @@ gain_capture(data, ...)
   ...,
   estimator = NULL,
   na_rm = TRUE,
-  event_level = yardstick_event_level()
+  event_level = yardstick_event_level(),
+  case_weights = NULL
 )
 
 gain_capture_vec(
@@ -23,6 +24,7 @@ gain_capture_vec(
   estimator = NULL,
   na_rm = TRUE,
   event_level = yardstick_event_level(),
+  case_weights = NULL,
   ...
 )
 }
@@ -56,6 +58,10 @@ applicable when \code{estimator = "binary"}. The default uses an
 internal helper that generally defaults to \code{"first"}, however, if the
 deprecated global option \code{yardstick.event_first} is set, that will be
 used instead with a warning.}
+
+\item{case_weights}{The optional column identifier for case weights. This
+should be an unquoted column name that evaluates to a numeric column in
+\code{data}. For \verb{_vec()} functions, a numeric vector.}
 
 \item{estimate}{If \code{truth} is binary, a numeric vector of class probabilities
 corresponding to the "relevant" class. Otherwise, a matrix with as many

--- a/tests/testthat/helper-macro-prob.R
+++ b/tests/testthat/helper-macro-prob.R
@@ -5,6 +5,43 @@ data_hpc_fold1 <- function() {
   dplyr::filter(hpc_cv, Resample == "Fold01")
 }
 
+hpc_fold1_macro_metric <- function(binary_metric, ...) {
+  hpc_f1 <- data_hpc_fold1()
+  truth <- hpc_f1$obs
+  prob_mat <- as.matrix(dplyr::select(hpc_f1, VF:L))
+  case_weights <- NULL
+
+  res <- rlang::flatten_dbl(one_vs_all_case_weights(
+    metric_fn = binary_metric,
+    truth = truth,
+    estimate = prob_mat,
+    case_weights = case_weights,
+    ...
+  ))
+
+  mean(res)
+}
+
+hpc_fold1_macro_weighted_metric <- function(binary_metric, ...) {
+  hpc_f1 <- data_hpc_fold1()
+  wt <- as.vector(table(hpc_f1$obs))
+  macro_wt <- wt / sum(wt)
+  truth <- hpc_f1$obs
+  prob_mat <- as.matrix(dplyr::select(hpc_f1, VF:L))
+  case_weights <- NULL
+
+  res <- rlang::flatten_dbl(one_vs_all_case_weights(
+    metric_fn = binary_metric,
+    truth = truth,
+    estimate = prob_mat,
+    case_weights = case_weights,
+    ...
+  ))
+
+  stats::weighted.mean(res, macro_wt)
+}
+
+# TODO: Remove this and all below when all prob metrics support case weights
 # These get embedded in the helper functions below
 hpc_f1 <- data_hpc_fold1()
 wt <- as.vector(table(hpc_f1$obs))

--- a/tests/testthat/test-prob-gain_capture.R
+++ b/tests/testthat/test-prob-gain_capture.R
@@ -59,11 +59,11 @@ test_that("Multiclass gain capture", {
 
   expect_equal(
     gain_capture(hpc_f1, obs, VF:L, estimator = "macro")[[".estimate"]],
-    prob_macro_metric(gain_capture_binary)
+    hpc_fold1_macro_metric(gain_capture_binary)
   )
   expect_equal(
     gain_capture(hpc_f1, obs, VF:L, estimator = "macro_weighted")[[".estimate"]],
-    prob_macro_weighted_metric(gain_capture_binary)
+    hpc_fold1_macro_weighted_metric(gain_capture_binary)
   )
 })
 
@@ -92,5 +92,43 @@ test_that("gain_capture = 2 * ROCAUC - 1", {
   expect_equal(
     gain_capture(hpc_f1, obs, VF:L, estimator = "macro")[[".estimate"]],
     stats::weighted.mean(2 * roc_auc_unweighted - 1, w)
+  )
+})
+
+# Case weights -----------------------------------------------------------------
+
+test_that('binary - case weights are applied correctly', {
+  df <- data.frame(
+    truth = factor(c("Yes", "No", "No", "Yes", "Yes"), levels = c("Yes", "No")),
+    estimate = c(.9, .8, .4, .68, .4),
+    weight = c(2, 1, 2, 1, 1)
+  )
+
+  df_expanded <- df[vec_rep_each(vec_seq_along(df), df$weight),]
+
+  expect_identical(
+    gain_capture(df, truth, estimate, case_weights = weight),
+    gain_capture(df_expanded, truth, estimate)
+  )
+})
+
+test_that("multiclass macro / macro_weighted - case weights are applied correctly", {
+  hpc_f1 <- data_hpc_fold1()
+
+  hpc_f1$weight <- rep(1L, times = nrow(hpc_f1))
+  hpc_f1$weight[c(2, 50, 200)] <- 3L
+
+  hpc_f1_expanded <- hpc_f1[vec_rep_each(vec_seq_along(hpc_f1), hpc_f1$weight),]
+
+  estimator <- "macro"
+  expect_identical(
+    gain_capture(hpc_f1, obs, VF:L, estimator = estimator, case_weights = weight)[[".estimate"]],
+    gain_capture(hpc_f1_expanded, obs, VF:L, estimator = estimator)[[".estimate"]]
+  )
+
+  estimator <- "macro_weighted"
+  expect_identical(
+    gain_capture(hpc_f1, obs, VF:L, estimator = estimator, case_weights = weight)[[".estimate"]],
+    gain_capture(hpc_f1_expanded, obs, VF:L, estimator = estimator)[[".estimate"]]
   )
 })

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -170,3 +170,24 @@ test_that("gain_curve() works with case weights and multiclass (ideally, frequen
   expect_s3_class(out, "gain_df")
   expect_identical(out, expect)
 })
+
+test_that("gain_curve() with case weights scales `.n` and `.n_events`", {
+  skip_if_not_installed("ggplot2")
+
+  # This is required for the `autoplot()` method
+  df <- data.frame(
+    truth = factor(c("Yes", "Yes", "No", "Yes", "No"), levels = c("Yes", "No")),
+    estimate = c(.9, .8, .7, .68, .5),
+    weight = c(2, 1, 1, 3, 2)
+  )
+
+  out <- gain_curve(df, truth, estimate, case_weights = weight)
+
+  plot <- ggplot2::autoplot(out)
+  data <- ggplot2::ggplot_build(plot)
+
+  grey_overlay_data <- data$data[[1]]
+
+  expect_equal(grey_overlay_data$x, c(0, 2/3 * 100, 100))
+  expect_equal(grey_overlay_data$y, c(0, 100, 100))
+})


### PR DESCRIPTION
And a `yardstick_truth_table()` that some of the other prob metrics will need. Notably, it uses case weights when generating the table so the `"macro_weighted"` averaging weights are correct (verified by a test that expands out the frequency weighted data frame and gets the same result as when weights are supplied)