### PR TITLE
Add case weight support to `conf_mat()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # yardstick (development version)
 
 * yardstick metrics now support case weights.
+  * conf_mat
 
   * Numeric:
     * ccc
@@ -44,6 +45,11 @@
     * mn_log_loss
     * pr_auc
     * pr_curve
+
+* `conf_mat()` now ignores any inputs passed through `...` and warns if you
+  try to do such a thing. Previously, those were passed on to `base::table()`,
+  but with the addition of case weight support, `table()` is no longer used
+  (#295).
 
 * Fixed a small mistake in `ccc()` where the unbiased covariance wasn't being
   used when `bias = FALSE`.

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -10,16 +10,21 @@
 \usage{
 conf_mat(data, ...)
 
-\method{conf_mat}{data.frame}(data, truth, estimate, dnn = c("Prediction", "Truth"), ...)
+\method{conf_mat}{data.frame}(
+  data,
+  truth,
+  estimate,
+  dnn = c("Prediction", "Truth"),
+  case_weights = NULL,
+  ...
+)
 
 \method{tidy}{conf_mat}(x, ...)
 }
 \arguments{
 \item{data}{A data frame or a \code{\link[base:table]{base::table()}}.}
 
-\item{...}{Options to pass to \code{\link[base:table]{base::table()}} (not including
-\code{dnn}). This argument is not currently used for the \code{tidy}
-method.}
+\item{...}{Not used.}
 
 \item{truth}{The column identifier for the true class results
 (that is a \code{factor}). This should be an unquoted column name although
@@ -33,6 +38,10 @@ specified different ways but the primary method is to use an
 unquoted variable name. For \verb{_vec()} functions, a \code{factor} vector.}
 
 \item{dnn}{A character vector of dimnames for the table.}
+
+\item{case_weights}{The optional column identifier for case weights.
+This should be an unquoted column name that evaluates to a numeric column
+in \code{data}. For \verb{_vec()} functions, a numeric vector.}
 
 \item{x}{A \code{conf_mat} object.}
 }

--- a/tests/testthat/_snaps/conf_mat.md
+++ b/tests/testthat/_snaps/conf_mat.md
@@ -1,0 +1,37 @@
+# `...` is deprecated with a warning
+
+    Code
+      conf_mat(two_class_example, truth, predicted, foo = 1)
+    Condition
+      Warning:
+      The `...` argument of `conf_mat()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+    Output
+                Truth
+      Prediction Class1 Class2
+          Class1    227     50
+          Class2     31    192
+
+---
+
+    Code
+      conf_mat(hpc_cv, obs, pred, foo = 1)
+    Condition
+      Warning:
+      The `...` argument of `conf_mat()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+    Output
+      # A tibble: 10 x 2
+         Resample conf_mat  
+         <chr>    <list>    
+       1 Fold01   <conf_mat>
+       2 Fold02   <conf_mat>
+       3 Fold03   <conf_mat>
+       4 Fold04   <conf_mat>
+       5 Fold05   <conf_mat>
+       6 Fold06   <conf_mat>
+       7 Fold07   <conf_mat>
+       8 Fold08   <conf_mat>
+       9 Fold09   <conf_mat>
+      10 Fold10   <conf_mat>
+

--- a/tests/testthat/test-conf_mat.R
+++ b/tests/testthat/test-conf_mat.R
@@ -3,6 +3,10 @@ test_that('Three class format', {
   three_class <- lst$three_class
   three_class_tb <- lst$three_class_tb
 
+  # Because of case weight support, `conf_mat()` returns a matrix not a table
+  three_class_tb <- unclass(three_class_tb)
+  storage.mode(three_class_tb) <- "double"
+
   expect_identical(
    conf_mat(three_class, truth = "obs", estimate = "pred", dnn = c("", ""))$table,
    three_class_tb
@@ -118,4 +122,68 @@ test_that('Tidy method', {
     "cell_1_1"
   )
 
+})
+
+test_that("can change the dimnames names", {
+  out <- conf_mat(two_class_example, truth, predicted, dnn = c("Foo", "Bar"))
+  expect_identical(names(dimnames(out$table)), c("Foo", "Bar"))
+})
+
+test_that("case weights are supported in data frame method", {
+  two_class_example$weight <- read_weights_two_class_example()
+
+  expect_identical(
+    conf_mat(two_class_example, truth, predicted, case_weights = weight)$table,
+    yardstick_table(
+      truth = two_class_example$truth,
+      estimate = two_class_example$predicted,
+      case_weights = two_class_example$weight
+    )
+  )
+})
+
+test_that("case weights propagate through to summary method metrics", {
+  two_class_example$weight <- read_weights_two_class_example()
+
+  out <- conf_mat(two_class_example, truth, predicted, case_weights = weight)
+  metrics <- summary(out)
+
+  accuracy <- metrics[metrics$.metric == "accuracy", ]
+  accuracy <- accuracy$.estimate
+
+  expect <- accuracy(two_class_example, truth, predicted, case_weights = weight)
+  expect <- expect[[".estimate"]]
+
+  expect_identical(accuracy, expect)
+})
+
+test_that("case weights are supported in grouped-df method", {
+  hpc_cv$weight <- read_weights_hpc_cv()
+
+  hpc_cv_f1 <- dplyr::filter(hpc_cv, Resample == "Fold01")
+
+  table_f1 <- yardstick_table(
+    truth = hpc_cv_f1$obs,
+    estimate = hpc_cv_f1$pred,
+    case_weights = hpc_cv_f1$weight
+  )
+  table_f1 <- conf_mat(table_f1)
+
+  hpc_cv <- dplyr::group_by(hpc_cv, Resample)
+  result <- conf_mat(hpc_cv, obs, pred, case_weights = weight)
+
+  expect_identical(
+    result$conf_mat[[1]],
+    table_f1
+  )
+})
+
+test_that("`...` is deprecated with a warning", {
+  skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
+  local_lifecycle_warnings()
+
+  expect_snapshot(conf_mat(two_class_example, truth, predicted, foo = 1))
+
+  hpc_cv <- dplyr::group_by(hpc_cv, Resample)
+  expect_snapshot(conf_mat(hpc_cv, obs, pred, foo = 1))
 })


### PR DESCRIPTION
- Added case weight support to `conf_mat()`
- Had to deprecate support for `...` in `conf_mat()`, which were passed on to `table()` but didn't do anything that was particularly interesting.
