### PR TITLE
Deprecate the `options` argument that is passed on to pROC

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,13 @@
     * pr_auc
     * pr_curve
 
+* The `options` argument of `roc_curve()`, `roc_auc()`, `roc_aunp()`,
+  `roc_aunu()`, and `metrics()` that was passed along to the pROC package is
+  now deprecated and no longer has any affect. This is a result of changing to
+  an ROC curve implementation that supports case weights, but does not support
+  any of the previous options. If you need these options, we suggest wrapping
+  pROC yourself in a custom metric (#296).
+
 * `conf_mat()` now ignores any inputs passed through `...` and warns if you
   try to do such a thing. Previously, those were passed on to `base::table()`,
   but with the addition of case weight support, `table()` is no longer used

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -72,8 +72,10 @@ metrics.data.frame <- function(data,
                                truth,
                                estimate,
                                ...,
-                               options = list(),
-                               na_rm = TRUE) {
+                               na_rm = TRUE,
+                               options = list()) {
+  check_roc_options_deprecated("metrics", options)
+
   names <- names(data)
 
   truth <- tidyselect::vars_pull(names, {{truth}})
@@ -88,7 +90,7 @@ metrics.data.frame <- function(data,
 
     if (length(probs) > 0L) {
       res2 <- mn_log_loss(data, !!truth, !!probs, na_rm = na_rm)
-      res3 <- roc_auc(data, !!truth, !!probs, na_rm = na_rm, options = options)
+      res3 <- roc_auc(data, !!truth, !!probs, na_rm = na_rm)
       res <- dplyr::bind_rows(res, res2, res3)
     }
   } else {

--- a/R/prob-binary-thresholds.R
+++ b/R/prob-binary-thresholds.R
@@ -1,0 +1,84 @@
+# For use with the `pr_curve()` and `roc_curve()`.
+# Returns a data frame with:
+# - Unique thresholds
+# - Number of true positives per threshold
+# - Number of false positives per threshold
+binary_threshold_curve <- function(truth,
+                                   estimate,
+                                   ...,
+                                   event_level = yardstick_event_level(),
+                                   case_weights = NULL) {
+  check_dots_empty()
+
+  if (is.null(case_weights)) {
+    case_weights <- rep(1, times = length(truth))
+  }
+  case_weights <- as.double(case_weights)
+
+  if (!is.factor(truth)) {
+    abort("`truth` must be a factor.", .internal = TRUE)
+  }
+  if (length(levels(truth)) != 2L) {
+    abort("`truth` must have two levels.", .internal = TRUE)
+  }
+  if (!is.numeric(estimate)) {
+    abort("`estimate` must be numeric.", .internal = TRUE)
+  }
+  if (length(truth) != length(estimate)) {
+    abort("`truth` and `estimate` must be the same length.", .internal = TRUE)
+  }
+  if (length(truth) != length(case_weights)) {
+    abort("`truth` and `case_weights` must be the same length.", .internal = TRUE)
+  }
+
+  truth <- unclass(truth)
+
+  # Convert to `1 == event`, `0 == non-event`
+  if (is_event_first(event_level)) {
+    truth <- as.integer(truth == 1L)
+  } else {
+    truth <- as.integer(truth == 2L)
+  }
+
+  # Drop any `0` weights.
+  # These shouldn't affect the result, but can result in divide by zero
+  # issues if they are left in.
+  detect_zero_weight <- case_weights == 0
+  if (any(detect_zero_weight)) {
+    detect_non_zero_weight <- !detect_zero_weight
+    truth <- truth[detect_non_zero_weight]
+    estimate <- estimate[detect_non_zero_weight]
+    case_weights <- case_weights[detect_non_zero_weight]
+  }
+
+  # Sort by decreasing `estimate`
+  order <- order(estimate, decreasing = TRUE)
+  truth <- truth[order]
+  estimate <- estimate[order]
+  case_weights <- case_weights[order]
+
+  # Skip repeated probabilities.
+  # We want the last duplicate to ensure that we capture all the events from the
+  # `cumsum()`, so we use `fromLast`.
+  loc_unique <- which(!duplicated(estimate, fromLast = TRUE))
+  thresholds <- estimate[loc_unique]
+
+  case_weights_events <- truth * case_weights
+  case_weights_non_events <- (1 - truth) * case_weights
+
+  if (sum(case_weights_events) == 0L) {
+    warn("There are `0` event cases in `truth`, results will be meaningless.")
+  }
+
+  tp <- cumsum(case_weights_events)
+  tp <- tp[loc_unique]
+
+  fp <- cumsum(case_weights_non_events)
+  fp <- fp[loc_unique]
+
+  dplyr::tibble(
+    threshold = thresholds,
+    tp = tp,
+    fp = fp
+  )
+}

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -77,18 +77,6 @@
 #'     ncol = 4
 #'   )
 #' )
-#'
-#' # ---------------------------------------------------------------------------
-#' # Options for `pROC::roc()`
-#'
-#' # Pass options via a named list and not through `...`!
-#' roc_aunp(
-#'   hpc_cv,
-#'   obs,
-#'   VF:L,
-#'   options = list(smooth = TRUE)
-#' )
-#'
 #' @export
 roc_aunp <- function(data, ...) {
   UseMethod("roc_aunp")
@@ -103,8 +91,10 @@ roc_aunp <- new_prob_metric(
 roc_aunp.data.frame <- function(data,
                                 truth,
                                 ...,
-                                options = list(),
-                                na_rm = TRUE) {
+                                na_rm = TRUE,
+                                options = list()) {
+  check_roc_options_deprecated("roc_aunp", options)
+
   estimate <- dots_to_estimate(data, !!! enquos(...))
 
   metric_summarizer(
@@ -115,8 +105,7 @@ roc_aunp.data.frame <- function(data,
     estimate = !!estimate,
     estimator = NULL,
     na_rm = na_rm,
-    event_level = NULL,
-    metric_fn_options = list(options = options)
+    event_level = NULL
   )
 }
 
@@ -124,9 +113,11 @@ roc_aunp.data.frame <- function(data,
 #' @export
 roc_aunp_vec <- function(truth,
                          estimate,
-                         options = list(),
                          na_rm = TRUE,
+                         options = list(),
                          ...) {
+  check_roc_options_deprecated("roc_aunp_vec", options)
+
   estimator <- "macro_weighted"
 
   # `event_level` doesn't really matter, but we set it anyways
@@ -134,7 +125,6 @@ roc_aunp_vec <- function(truth,
     roc_auc_vec(
       truth = truth,
       estimate = estimate,
-      options = options,
       estimator = estimator,
       na_rm = FALSE,
       event_level = "first"

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -77,18 +77,6 @@
 #'     ncol = 4
 #'   )
 #' )
-#'
-#' # ---------------------------------------------------------------------------
-#' # Options for `pROC::roc()`
-#'
-#' # Pass options via a named list and not through `...`!
-#' roc_aunu(
-#'   hpc_cv,
-#'   obs,
-#'   VF:L,
-#'   options = list(smooth = TRUE)
-#' )
-#'
 #' @export
 roc_aunu <- function(data, ...) {
   UseMethod("roc_aunu")
@@ -103,8 +91,10 @@ roc_aunu <- new_prob_metric(
 roc_aunu.data.frame  <- function(data,
                                  truth,
                                  ...,
-                                 options = list(),
-                                 na_rm = TRUE) {
+                                 na_rm = TRUE,
+                                 options = list()) {
+  check_roc_options_deprecated("roc_aunu", options)
+
   estimate <- dots_to_estimate(data, !!! enquos(...))
 
   metric_summarizer(
@@ -115,8 +105,7 @@ roc_aunu.data.frame  <- function(data,
     estimate = !!estimate,
     estimator = NULL,
     na_rm = na_rm,
-    event_level = NULL,
-    metric_fn_options = list(options = options)
+    event_level = NULL
   )
 }
 
@@ -124,9 +113,11 @@ roc_aunu.data.frame  <- function(data,
 #' @export
 roc_aunu_vec <- function(truth,
                          estimate,
-                         options = list(),
                          na_rm = TRUE,
+                         options = list(),
                          ...) {
+  check_roc_options_deprecated("roc_aunu_vec", options)
+
   estimator <- "macro"
 
   # `event_level` doesn't really matter, but we set it anyways
@@ -134,7 +125,6 @@ roc_aunu_vec <- function(truth,
     roc_auc_vec(
       truth = truth,
       estimate = estimate,
-      options = options,
       estimator = estimator,
       na_rm = FALSE,
       event_level = "first"

--- a/man/metrics.Rd
+++ b/man/metrics.Rd
@@ -7,7 +7,7 @@
 \usage{
 metrics(data, ...)
 
-\method{metrics}{data.frame}(data, truth, estimate, ..., options = list(), na_rm = TRUE)
+\method{metrics}{data.frame}(data, truth, estimate, ..., na_rm = TRUE, options = list())
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}
@@ -29,12 +29,16 @@ names).}
 specified different ways but the primary method is to use an
 unquoted variable name.}
 
-\item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
-
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
+
+\item{options}{\verb{[deprecated]}
+
+No longer supported as of yardstick 1.0.0. If you pass something here it
+will be ignored with a warning.
+
+Previously, these were options passed on to \code{pROC::roc()}. If you need
+support for this, use the pROC package directly.}
 }
 \value{
 A three column tibble.

--- a/man/roc_auc.Rd
+++ b/man/roc_auc.Rd
@@ -12,19 +12,19 @@ roc_auc(data, ...)
   data,
   truth,
   ...,
-  options = list(),
   estimator = NULL,
   na_rm = TRUE,
-  event_level = yardstick_event_level()
+  event_level = yardstick_event_level(),
+  options = list()
 )
 
 roc_auc_vec(
   truth,
   estimate,
-  options = list(),
   estimator = NULL,
   na_rm = TRUE,
   event_level = yardstick_event_level(),
+  options = list(),
   ...
 )
 }
@@ -43,10 +43,6 @@ this argument is passed by expression and supports
 \link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
-\item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
-
 \item{estimator}{One of \code{"binary"}, \code{"hand_till"}, \code{"macro"}, or
 \code{"macro_weighted"} to specify the type of averaging to be done. \code{"binary"}
 is only relevant for the two class case. The others are general methods for
@@ -62,6 +58,14 @@ applicable when \code{estimator = "binary"}. The default uses an
 internal helper that generally defaults to \code{"first"}, however, if the
 deprecated global option \code{yardstick.event_first} is set, that will be
 used instead with a warning.}
+
+\item{options}{\verb{[deprecated]}
+
+No longer supported as of yardstick 1.0.0. If you pass something here it
+will be ignored with a warning.
+
+Previously, these were options passed on to \code{pROC::roc()}. If you need
+support for this, use the pROC package directly.}
 
 \item{estimate}{If \code{truth} is binary, a numeric vector of class probabilities
 corresponding to the "relevant" class. Otherwise, a matrix with as many
@@ -178,17 +182,6 @@ roc_auc_vec(
      c(fold1$VF, fold1$F, fold1$M, fold1$L),
      ncol = 4
    )
-)
-
-# ---------------------------------------------------------------------------
-# Options for `pROC::roc()`
-
-# Pass options via a named list and not through `...`!
-roc_auc(
-  two_class_example,
-  truth = truth,
-  Class1,
-  options = list(smooth = TRUE)
 )
 
 }

--- a/man/roc_aunp.Rd
+++ b/man/roc_aunp.Rd
@@ -9,9 +9,9 @@ class distribution}
 \usage{
 roc_aunp(data, ...)
 
-\method{roc_aunp}{data.frame}(data, truth, ..., options = list(), na_rm = TRUE)
+\method{roc_aunp}{data.frame}(data, truth, ..., na_rm = TRUE, options = list())
 
-roc_aunp_vec(truth, estimate, options = list(), na_rm = TRUE, ...)
+roc_aunp_vec(truth, estimate, na_rm = TRUE, options = list(), ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}
@@ -27,12 +27,16 @@ this argument is passed by expression and supports
 \link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
-\item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
-
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
+
+\item{options}{\verb{[deprecated]}
+
+No longer supported as of yardstick 1.0.0. If you pass something here it
+will be ignored with a warning.
+
+Previously, these were options passed on to \code{pROC::roc()}. If you need
+support for this, use the pROC package directly.}
 
 \item{estimate}{A matrix with as many
 columns as factor levels of \code{truth}. \emph{It is assumed that these are in the
@@ -111,18 +115,6 @@ roc_aunp_vec(
     ncol = 4
   )
 )
-
-# ---------------------------------------------------------------------------
-# Options for `pROC::roc()`
-
-# Pass options via a named list and not through `...`!
-roc_aunp(
-  hpc_cv,
-  obs,
-  VF:L,
-  options = list(smooth = TRUE)
-)
-
 }
 \references{
 Ferri, C., Hernández-Orallo, J., & Modroiu, R. (2009). "An experimental

--- a/man/roc_aunu.Rd
+++ b/man/roc_aunu.Rd
@@ -9,9 +9,9 @@ class distribution}
 \usage{
 roc_aunu(data, ...)
 
-\method{roc_aunu}{data.frame}(data, truth, ..., options = list(), na_rm = TRUE)
+\method{roc_aunu}{data.frame}(data, truth, ..., na_rm = TRUE, options = list())
 
-roc_aunu_vec(truth, estimate, options = list(), na_rm = TRUE, ...)
+roc_aunu_vec(truth, estimate, na_rm = TRUE, options = list(), ...)
 }
 \arguments{
 \item{data}{A \code{data.frame} containing the \code{truth} and \code{estimate}
@@ -27,12 +27,16 @@ this argument is passed by expression and supports
 \link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
-\item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
-
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
+
+\item{options}{\verb{[deprecated]}
+
+No longer supported as of yardstick 1.0.0. If you pass something here it
+will be ignored with a warning.
+
+Previously, these were options passed on to \code{pROC::roc()}. If you need
+support for this, use the pROC package directly.}
 
 \item{estimate}{A matrix with as many
 columns as factor levels of \code{truth}. \emph{It is assumed that these are in the
@@ -111,18 +115,6 @@ roc_aunu_vec(
     ncol = 4
   )
 )
-
-# ---------------------------------------------------------------------------
-# Options for `pROC::roc()`
-
-# Pass options via a named list and not through `...`!
-roc_aunu(
-  hpc_cv,
-  obs,
-  VF:L,
-  options = list(smooth = TRUE)
-)
-
 }
 \references{
 Ferri, C., Hernández-Orallo, J., & Modroiu, R. (2009). "An experimental

--- a/man/roc_curve.Rd
+++ b/man/roc_curve.Rd
@@ -11,9 +11,9 @@ roc_curve(data, ...)
   data,
   truth,
   ...,
-  options = list(),
   na_rm = TRUE,
-  event_level = yardstick_event_level()
+  event_level = yardstick_event_level(),
+  options = list()
 )
 }
 \arguments{
@@ -31,10 +31,6 @@ this argument is passed by expression and supports
 \link[rlang:topic-inject]{quasiquotation} (you can unquote column
 names). For \verb{_vec()} functions, a \code{factor} vector.}
 
-\item{options}{A \code{list} of named options to pass to \code{\link[pROC:roc]{pROC::roc()}}
-such as \code{smooth}. These options should not include \code{response},
-\code{predictor}, \code{levels}, \code{quiet}, or \code{direction}.}
-
 \item{na_rm}{A \code{logical} value indicating whether \code{NA}
 values should be stripped before the computation proceeds.}
 
@@ -44,6 +40,14 @@ applicable when \code{estimator = "binary"}. The default uses an
 internal helper that generally defaults to \code{"first"}, however, if the
 deprecated global option \code{yardstick.event_first} is set, that will be
 used instead with a warning.}
+
+\item{options}{\verb{[deprecated]}
+
+No longer supported as of yardstick 1.0.0. If you pass something here it
+will be ignored with a warning.
+
+Previously, these were options passed on to \code{pROC::roc()}. If you need
+support for this, use the pROC package directly.}
 }
 \value{
 A tibble with class \code{roc_df} or \code{roc_grouped_df} having

--- a/tests/testthat/_snaps/error-handling.md
+++ b/tests/testthat/_snaps/error-handling.md
@@ -139,7 +139,7 @@
     Output
       <error/rlang_error>
       Error in `dplyr::summarise()`:
-      ! Problem while computing `.estimate = metric_fn(...)`.
+      ! Problem while computing `.estimate = metric_fn(truth = obs, estimate = VF, na_rm = na_rm, event_level = "first")`.
       Caused by error in `multiclass_checks.matrix()`:
       ! The number of levels in `truth` (4) must match the number of columns supplied in `...` (1).
 

--- a/tests/testthat/_snaps/metrics.md
+++ b/tests/testthat/_snaps/metrics.md
@@ -1,3 +1,13 @@
+# metrics() - `options` is deprecated
+
+    Code
+      out <- metrics(two_class_example, truth, predicted, Class1, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `metrics()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+
 # print metric_set works
 
     Code

--- a/tests/testthat/_snaps/prob-roc.md
+++ b/tests/testthat/_snaps/prob-roc.md
@@ -76,3 +76,34 @@
       No observations were detected in `truth` for level(s): 'y', 'z'
       Computation will proceed by ignoring those levels.
 
+# roc_curve() - `options` is deprecated
+
+    Code
+      out <- roc_curve(two_class_example, truth, Class1, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_curve()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+
+# roc_auc() - `options` is deprecated
+
+    Code
+      out <- roc_auc(two_class_example, truth, Class1, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_auc()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+
+---
+
+    Code
+      out <- roc_auc_vec(truth = two_class_example$truth, estimate = two_class_example$
+        Class1, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_auc_vec()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+

--- a/tests/testthat/_snaps/prob-roc_aunp.md
+++ b/tests/testthat/_snaps/prob-roc_aunp.md
@@ -5,7 +5,28 @@
     Output
       <error/rlang_error>
       Error in `dplyr::summarise()`:
-      ! Problem while computing `.estimate = metric_fn(truth = truth, estimate = Class1, na_rm = na_rm, options = list())`.
+      ! Problem while computing `.estimate = metric_fn(truth = truth, estimate = Class1, na_rm = na_rm)`.
       Caused by error in `multiclass_checks.matrix()`:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
+
+# roc_aunp() - `options` is deprecated
+
+    Code
+      out <- roc_aunp(two_class_example, truth, Class1, Class2, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_aunp()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+
+---
+
+    Code
+      out <- roc_aunp_vec(truth = two_class_example$truth, estimate = as.matrix(
+        two_class_example[c("Class1", "Class2")]), options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_aunp_vec()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
 

--- a/tests/testthat/_snaps/prob-roc_aunu.md
+++ b/tests/testthat/_snaps/prob-roc_aunu.md
@@ -5,7 +5,28 @@
     Output
       <error/rlang_error>
       Error in `dplyr::summarise()`:
-      ! Problem while computing `.estimate = metric_fn(truth = truth, estimate = Class1, na_rm = na_rm, options = list())`.
+      ! Problem while computing `.estimate = metric_fn(truth = truth, estimate = Class1, na_rm = na_rm)`.
       Caused by error in `multiclass_checks.matrix()`:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
+
+# roc_aunu() - `options` is deprecated
+
+    Code
+      out <- roc_aunu(two_class_example, truth, Class1, Class2, options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_aunu()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
+
+---
+
+    Code
+      out <- roc_aunu_vec(truth = two_class_example$truth, estimate = as.matrix(
+        two_class_example[c("Class1", "Class2")]), options = 1)
+    Condition
+      Warning:
+      The `options` argument of `roc_aunu_vec()` is deprecated as of yardstick 1.0.0.
+      This argument no longer has any effect, and is being ignored.
+      Use the pROC package directly if you need these features.
 

--- a/tests/testthat/test-metric-tweak.R
+++ b/tests/testthat/test-metric-tweak.R
@@ -44,12 +44,14 @@ test_that("can tweak a class metric that doesn't use `estimator`", {
 })
 
 test_that("can tweak a class prob metric", {
-  roc_auc2 <- metric_tweak("roc_auc2", roc_auc, options = list(smooth = TRUE))
+  two_class_example$truth[1] <- NA
+
+  roc_auc2 <- metric_tweak("roc_auc2", roc_auc, na_rm = FALSE)
   result <- roc_auc2(two_class_example, truth, Class1)
 
   expect_identical(
     result[[".estimate"]],
-    roc_auc(two_class_example, truth, Class1, options = list(smooth = TRUE))[[".estimate"]]
+    roc_auc(two_class_example, truth, Class1, na_rm = FALSE)[[".estimate"]]
   )
 
   expect_identical(
@@ -87,7 +89,7 @@ test_that("can tweak a class prob metric that doesn't use `estimator`", {
 test_that("can combine tweaked metrics into a metric set", {
   f_meas2 <- metric_tweak("f_meas2", f_meas, beta = 2)
   ppv2 <- metric_tweak("ppv2", ppv, prevalence = .4)
-  roc_auc2 <- metric_tweak("roc_auc2", roc_auc, options = list(smooth = TRUE))
+  roc_auc2 <- metric_tweak("roc_auc2", roc_auc)
 
   set <- metric_set(f_meas2, ppv2, roc_auc2)
   result <- set(two_class_example, truth, Class1, estimate = predicted)

--- a/tests/testthat/test-prob-gain_capture.R
+++ b/tests/testthat/test-prob-gain_capture.R
@@ -82,8 +82,7 @@ test_that("gain_capture = 2 * ROCAUC - 1", {
   # must do (2 * ROCAUC - 1) BEFORE weighting
   roc_auc_unweighted <- yardstick:::roc_auc_multiclass(
     hpc_f1$obs,
-    as.matrix(hpc_f1[,c("VF", "F", "M", "L")]),
-    list()
+    as.matrix(hpc_f1[,c("VF", "F", "M", "L")])
   )
 
   truth_table <- matrix(table(hpc_f1$obs), nrow = 1)

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -25,3 +25,34 @@ test_that("AUNP results match mlr for soybean example", {
   )
 })
 
+# ------------------------------------------------------------------------------
+
+test_that("roc_aunp() - `options` is deprecated", {
+  skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
+  local_lifecycle_warnings()
+
+  expect_snapshot({
+    out <- roc_aunp(two_class_example, truth, Class1, Class2, options = 1)
+  })
+
+  expect_identical(
+    out,
+    roc_aunp(two_class_example, truth, Class1, Class2)
+  )
+
+  expect_snapshot({
+    out <- roc_aunp_vec(
+      truth = two_class_example$truth,
+      estimate = as.matrix(two_class_example[c("Class1", "Class2")]),
+      options = 1
+    )
+  })
+
+  expect_identical(
+    out,
+    roc_aunp_vec(
+      truth = two_class_example$truth,
+      estimate = as.matrix(two_class_example[c("Class1", "Class2")])
+    )
+  )
+})

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -25,3 +25,34 @@ test_that("AUNU results match mlr for soybean example", {
   )
 })
 
+# ------------------------------------------------------------------------------
+
+test_that("roc_aunu() - `options` is deprecated", {
+  skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
+  local_lifecycle_warnings()
+
+  expect_snapshot({
+    out <- roc_aunu(two_class_example, truth, Class1, Class2, options = 1)
+  })
+
+  expect_identical(
+    out,
+    roc_aunu(two_class_example, truth, Class1, Class2),
+  )
+
+  expect_snapshot({
+    out <- roc_aunu_vec(
+      truth = two_class_example$truth,
+      estimate = as.matrix(two_class_example[c("Class1", "Class2")]),
+      options = 1
+    )
+  })
+
+  expect_identical(
+    out,
+    roc_aunu_vec(
+      truth = two_class_example$truth,
+      estimate = as.matrix(two_class_example[c("Class1", "Class2")])
+    )
+  )
+})

--- a/tests/testthat/test_metrics.R
+++ b/tests/testthat/test_metrics.R
@@ -82,6 +82,22 @@ test_that('correct results', {
 
 ###################################################################
 
+test_that("metrics() - `options` is deprecated", {
+  skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
+  local_lifecycle_warnings()
+
+  expect_snapshot({
+    out <- metrics(two_class_example, truth, predicted, Class1, options = 1)
+  })
+
+  expect_identical(
+    out,
+    metrics(two_class_example, truth, predicted, Class1)
+  )
+})
+
+###################################################################
+
 test_that('numeric metric sets', {
 
   reg_set <- metric_set(rmse, rsq, mae)


### PR DESCRIPTION
This is in preparation of a switch to a custom roc-curve implementation that supports case weights.

It will no longer support any of the `options` passed on to pROC, so we have to deprecate that argument. It was present in:
- `roc_curve()`
- `roc_auc()`
- `roc_aunp()`
- `roc_aunu()`
- `metrics()`

Also contains a little cleanup of the pr-curve internals. Extracted `binary_threshold_curve()` for use in roc-curve.