### PR TITLE
Remove the pROC dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     dplyr (>= 1.0.8),
     generics,
     hardhat (>= 0.2.0.9000),
-    pROC (>= 1.15.0),
     rlang (>= 1.0.1),
     tidyselect (>= 1.1.2),
     utils,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # yardstick (development version)
 
+* The pROC package has been removed as a dependency (#300).
+
 * All yardstick metrics now support case weights through the `case_weights`
   argument. This also includes metric-adjacent functions like `roc_curve()`,
   `pr_curve()`, `conf_mat()`, and `metric_set()`.


### PR DESCRIPTION
With case weight support, our roc-curve now uses a custom implementation, and we don't use pROC at all anymore