### PR TITLE
Ensure that hardhat case weights are supported everywhere

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -103,6 +103,7 @@ yardstick_mean <- function(x, ..., case_weights = NULL, na_remove = FALSE) {
   if (is.null(case_weights)) {
     mean(x, na.rm = na_remove)
   } else {
+    case_weights <- vec_cast(case_weights, to = double())
     stats::weighted.mean(x, w = case_weights, na.rm = na_remove)
   }
 }
@@ -113,6 +114,8 @@ yardstick_sum <- function(x, ..., case_weights = NULL, na_remove = FALSE) {
   if (is.null(case_weights)) {
     sum(x, na.rm = na_remove)
   } else {
+    case_weights <- vec_cast(case_weights, to = double())
+
     if (na_remove) {
       # Only remove `NA`s found in `x`, copies `stats::weighted.mean()`
       keep <- !is.na(x)

--- a/R/num-ccc.R
+++ b/R/num-ccc.R
@@ -92,6 +92,8 @@ ccc_impl <- function(truth,
                      case_weights = NULL) {
   check_dots_empty()
 
+  case_weights <- vec_cast(case_weights, to = double())
+
   truth_mean <- yardstick_mean(truth, case_weights = case_weights)
   estimate_mean <- yardstick_mean(estimate, case_weights = case_weights)
 

--- a/R/prob-binary-thresholds.R
+++ b/R/prob-binary-thresholds.R
@@ -13,7 +13,7 @@ binary_threshold_curve <- function(truth,
   if (is.null(case_weights)) {
     case_weights <- rep(1, times = length(truth))
   }
-  case_weights <- as.double(case_weights)
+  case_weights <- vec_cast(case_weights, to = double())
 
   if (!is.factor(truth)) {
     abort("`truth` must be a factor.", .internal = TRUE)

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -211,6 +211,7 @@ gain_curve_binary_impl <- function(truth,
   if (is.null(case_weights)) {
     case_weights <- rep(1, times = length(truth))
   }
+  case_weights <- vec_cast(case_weights, to = double())
 
   # arrange in decreasing order by class probability score
   estimate_ord <- order(estimate, decreasing = TRUE)

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -77,6 +77,29 @@ test_that("case weights must be numeric", {
   expect_snapshot(error = TRUE, yardstick_table(x, x, case_weights = "x"))
 })
 
+test_that("works with hardhat case weights", {
+  x <- factor(c("x", "y", "x"), levels = c("x", "y"))
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_table(x, x, case_weights = w),
+    yardstick_table(x, x, case_weights = as.integer(w))
+  )
+})
+
+# ------------------------------------------------------------------------------
+# yardstick_mean()
+
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_mean(x, case_weights = w),
+    2 + 4/9
+  )
+})
+
 # ------------------------------------------------------------------------------
 # yardstick_sum()
 
@@ -94,6 +117,16 @@ test_that("`na_remove` only removes NAs present in `x`", {
 
   expect_identical(yardstick_sum(x, case_weights = w), NA_real_)
   expect_identical(yardstick_sum(x, case_weights = w, na_remove = TRUE), NA_real_)
+})
+
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_sum(x, case_weights = w),
+    22
+  )
 })
 
 # ------------------------------------------------------------------------------
@@ -116,6 +149,16 @@ test_that("works with input of size 0", {
   expect_identical(yardstick_sd(double()), sd(double()))
 })
 
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_sd(x, case_weights = w),
+    yardstick_sd(x, case_weights = as.integer(w))
+  )
+})
+
 # ------------------------------------------------------------------------------
 # yardstick_var()
 
@@ -134,6 +177,16 @@ test_that("works with input of size 1", {
 test_that("works with input of size 0", {
   expect_identical(yardstick_var(double()), NA_real_)
   expect_identical(yardstick_var(double()), var(double()))
+})
+
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_var(x, case_weights = w),
+    yardstick_var(x, case_weights = as.integer(w))
+  )
 })
 
 # ------------------------------------------------------------------------------
@@ -169,8 +222,18 @@ test_that("works with input of size 0", {
   expect_identical(yardstick_cov(double(), double()), cov(double(), double()))
 })
 
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_cov(x, x, case_weights = w),
+    yardstick_cov(x, x, case_weights = as.integer(w))
+  )
+})
+
 # ------------------------------------------------------------------------------
-# yardstick_cov()
+# yardstick_cor()
 
 test_that("works with constant inputs", {
   expect_snapshot({
@@ -210,6 +273,16 @@ test_that("warns with input of size 0", {
   expect_identical(out, NA_real_)
 })
 
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    yardstick_cor(x, x, case_weights = w),
+    yardstick_cor(x, x, case_weights = as.integer(w))
+  )
+})
+
 # ------------------------------------------------------------------------------
 # weighted_quantile()
 
@@ -241,6 +314,16 @@ test_that("works with one value", {
 
 test_that("works with zero percentiles", {
   expect_identical(weighted_quantile(1:5, 1:5, numeric()), numeric())
+})
+
+test_that("works with hardhat case weights", {
+  x <- 1:3
+  w <- hardhat::frequency_weights(c(1, 3, 5))
+
+  expect_identical(
+    weighted_quantile(x, w, .5),
+    weighted_quantile(x, as.integer(w), .5)
+  )
 })
 
 test_that("`x` is validated", {

--- a/tests/testthat/test-num-ccc.R
+++ b/tests/testthat/test-num-ccc.R
@@ -53,3 +53,16 @@ test_that("case weights are utilized", {
   expect_true(weighted_unbiased != unweighted_unbiased)
   expect_true(weighted_unbiased != weighted_biased)
 })
+
+test_that("can use hardhat case weights", {
+  solubility_test$weights <- read_weights_solubility_test()
+  expect1 <- ccc(solubility_test, solubility, prediction, case_weights = weights, bias = TRUE)
+  expect2 <- ccc(solubility_test, solubility, prediction, case_weights = weights, bias = FALSE)
+
+  solubility_test$weights <- hardhat::importance_weights(solubility_test$weights)
+  result1 <- ccc(solubility_test, solubility, prediction, case_weights = weights, bias = TRUE)
+  result2 <- ccc(solubility_test, solubility, prediction, case_weights = weights, bias = FALSE)
+
+  expect_identical(result1, expect1)
+  expect_identical(result2, expect2)
+})

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -191,3 +191,19 @@ test_that("gain_curve() with case weights scales `.n` and `.n_events`", {
   expect_equal(grey_overlay_data$x, c(0, 2/3 * 100, 100))
   expect_equal(grey_overlay_data$y, c(0, 100, 100))
 })
+
+test_that("gain_curve() works with hardhat case weights", {
+  df <- data.frame(
+    truth = factor(c("Yes", "Yes", "No", "Yes", "No"), levels = c("Yes", "No")),
+    estimate = c(.9, .8, .7, .68, .5),
+    weight = c(2, 1, 1, 3, 2)
+  )
+
+  curve1 <- gain_curve(df, truth, estimate, case_weights = weight)
+
+  df$weight <- hardhat::frequency_weights(df$weight)
+
+  curve2 <- gain_curve(df, truth, estimate, case_weights = weight)
+
+  expect_identical(curve1, curve2)
+})

--- a/tests/testthat/test-prob-roc_curve.R
+++ b/tests/testthat/test-prob-roc_curve.R
@@ -68,6 +68,16 @@ test_that("grouped multiclass (one-vs-all) weighted example matches expanded equ
   )
 })
 
+test_that("can use hardhat case weights", {
+  two_class_example$weight <- read_weights_two_class_example()
+  curve1 <- roc_curve(two_class_example, truth, Class1, case_weights = weight)
+
+  two_class_example$weight <- hardhat::importance_weights(two_class_example$weight)
+  curve2 <- roc_curve(two_class_example, truth, Class1, case_weights = weight)
+
+  expect_identical(curve1, curve2)
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("zero weights don't affect the curve", {


### PR DESCRIPTION
Mainly involves a few key conversions to double.

The alternative is to make the case weights classes in hardhat directly support arithmetic and math operations, but I'm not quite sure we want that. I feel like wrapping the column up in a case weights class has a very specific meaning, and you should unwrap it to make it work more like a double/integer vector again.