### PR TITLE
update snapshot of internal yardstick_table

### DIFF
--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -5,7 +5,8 @@
     Condition
       Error in `yardstick_table()`:
       ! `truth` must be a factor.
-      i This is an internal error in the yardstick package, please report it to the package authors.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -14,7 +15,8 @@
     Condition
       Error in `yardstick_table()`:
       ! `estimate` must be a factor.
-      i This is an internal error in the yardstick package, please report it to the package authors.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 # levels must be exactly the same
 
@@ -23,7 +25,8 @@
     Condition
       Error in `yardstick_table()`:
       ! `truth` and `estimate` must have the same levels in the same order.
-      i This is an internal error in the yardstick package, please report it to the package authors.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 ---
 
@@ -32,7 +35,8 @@
     Condition
       Error in `yardstick_table()`:
       ! `truth` and `estimate` must have the same levels in the same order.
-      i This is an internal error in the yardstick package, please report it to the package authors.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 # must have at least 2 levels
 
@@ -41,7 +45,8 @@
     Condition
       Error in `yardstick_table()`:
       ! `truth` must have at least 2 factor levels.
-      i This is an internal error in the yardstick package, please report it to the package authors.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
 
 # case weights must be numeric
 


### PR DESCRIPTION
The new {rlang} version introduced links in internal errors https://github.com/r-lib/rlang/commit/a72c03c5c9e9d72c94c27082d5298a394577af69. This PR updates the 5 affected snapshots