### PR TITLE
depend on tidyselect 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     hardhat (>= 1.0.0),
     lifecycle (>= 1.0.3),
     rlang (>= 1.0.6),
-    tidyselect (>= 1.1.2),
+    tidyselect (>= 1.2.0),
     utils,
     vctrs (>= 0.5.0)
 Suggests: 


### PR DESCRIPTION
The changes made in https://github.com/tidymodels/yardstick/pull/322 uses tidyselect 1.2.0 features. This was not reflected in the required version denoted by the DESCRIPTION file. This PR fixes that