### PR TITLE
consistent aspect ratio for PR curves

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
   
 * yardstick metric functions now use a pure tidyselect interface for `truth`, 
   `estimate`, and the `...` of class probability metrics (#322).
+  
+* Changed the default aspect ratio for PR curves to be 1.0. 
 
 # yardstick 1.1.0
 

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -235,7 +235,7 @@ autoplot.pr_df <- function(object, ...) {
   pr_chart <- pr_chart %+%
     ggplot2::geom_path(mapping = aes_spliced) %+%
     ggplot2::lims(x = c(0, 1), y = c(0, 1)) %+%
-    ggplot2::coord_equal(ratio = .75) %+%
+    ggplot2::coord_equal(ratio = 1) %+%
     ggplot2::theme_bw()
 
   # If we have .level, that means this was multiclass


### PR DESCRIPTION
All of our probability curve `autoplot()` methods use an aspect ratio of 1.00 except PR curves. They all have aces that are on 0:1 and it makes sense to keep them squares. 