### PR TITLE
Hard deprecate yardstick.event first

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # yardstick (development version)
 
+* The global option, `yardstick.event_first`, has been hard deprecated in favor
+  of using explicit argument, `event_level`. Setting this option will now 
+  produce an warning, but won't have any effect. (#173)
+
 * The Brier score for classification was added (#139).
 
 * `metric_vec_template()` is being soft deprecated in favor of a more manual

--- a/R/event-level.R
+++ b/R/event-level.R
@@ -8,34 +8,17 @@
 yardstick_event_level <- function() {
   opt <- getOption("yardstick.event_first")
 
-  if (is.null(opt)) {
-    return("first")
+  if (!is.null(opt)) {
+    lifecycle::deprecate_warn(
+      when = "0.0.7",
+      what = I("The global option `yardstick.event_first`"),
+      with = I("the metric function argument `event_level`"),
+      details = "The global option is being ignored entirely."
+    )
   }
 
-  warn_event_first_deprecated()
-
-  if (identical(opt, TRUE)) {
-    "first"
-  } else if (identical(opt, FALSE)) {
-    "second"
-  } else {
-    abort("Global option `yardstick.event_first` is set, but is not `TRUE` or `FALSE`.")
-  }
+  "first"
 }
-
-warn_event_first_deprecated <- function() {
-  msg <- paste0(
-    "The `yardstick.event_first` option has been deprecated as of ",
-    "yardstick 0.0.7 and will be completely ignored in a future version.\n",
-    "Instead, set the following argument directly in the metric function:\n",
-    "`options(yardstick.event_first = TRUE)`  -> `event_level = 'first'` (the default)\n",
-    "`options(yardstick.event_first = FALSE)` -> `event_level = 'second'`"
-  )
-
-  # Will only warn once per session!
-  warn_deprecated(msg)
-}
-
 
 is_event_first <- function(event_level) {
   validate_event_level(event_level)

--- a/tests/testthat/_snaps/event-level.md
+++ b/tests/testthat/_snaps/event-level.md
@@ -1,22 +1,20 @@
-# `yardstick_event_level()` respects option - TRUE, with a warning
+# `yardstick_event_level()` ignores option - TRUE, with a warning
 
     Code
       out <- yardstick_event_level()
     Condition
       Warning:
-      The `yardstick.event_first` option has been deprecated as of yardstick 0.0.7 and will be completely ignored in a future version.
-      Instead, set the following argument directly in the metric function:
-      `options(yardstick.event_first = TRUE)`  -> `event_level = 'first'` (the default)
-      `options(yardstick.event_first = FALSE)` -> `event_level = 'second'`
+      The global option `yardstick.event_first` was deprecated in yardstick 0.0.7.
+      i Please use the metric function argument `event_level` instead.
+      i The global option is being ignored entirely.
 
-# `yardstick_event_level()` respects option - FALSE, with a warning
+# `yardstick_event_level()` ignores option - FALSE, with a warning
 
     Code
       out <- yardstick_event_level()
     Condition
       Warning:
-      The `yardstick.event_first` option has been deprecated as of yardstick 0.0.7 and will be completely ignored in a future version.
-      Instead, set the following argument directly in the metric function:
-      `options(yardstick.event_first = TRUE)`  -> `event_level = 'first'` (the default)
-      `options(yardstick.event_first = FALSE)` -> `event_level = 'second'`
+      The global option `yardstick.event_first` was deprecated in yardstick 0.0.7.
+      i Please use the metric function argument `event_level` instead.
+      i The global option is being ignored entirely.
 

--- a/tests/testthat/test-event-level.R
+++ b/tests/testthat/test-event-level.R
@@ -2,7 +2,7 @@ test_that("`yardstick_event_level()` defaults to 'first'", {
   expect_identical(yardstick_event_level(), "first")
 })
 
-test_that("`yardstick_event_level()` respects option - TRUE, with a warning", {
+test_that("`yardstick_event_level()` ignores option - TRUE, with a warning", {
   skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
   local_lifecycle_warnings()
   rlang::local_options(yardstick.event_first = TRUE)
@@ -10,11 +10,11 @@ test_that("`yardstick_event_level()` respects option - TRUE, with a warning", {
   expect_identical(out, "first")
 })
 
-test_that("`yardstick_event_level()` respects option - FALSE, with a warning", {
+test_that("`yardstick_event_level()` ignores option - FALSE, with a warning", {
   skip_if(getRversion() <= "3.5.3", "Base R used a different deprecated warning class.")
   local_lifecycle_warnings()
   rlang::local_options(yardstick.event_first = FALSE)
   expect_snapshot(out <- yardstick_event_level())
-  expect_identical(out, "second")
+  expect_identical(out, "first")
 })
 

--- a/tests/testthat/test-global-option.R
+++ b/tests/testthat/test-global-option.R
@@ -7,38 +7,37 @@ path_tbl <- lst$path_tbl
 test_that('switch event definition', {
   rlang::local_options(
     yardstick.event_first = FALSE,
-    lifecycle_disable_warnings = TRUE
+    lifecycle_verbosity = "quiet"
   )
 
   expect_equal(
     sens(pathology, truth = "pathology", estimate = "scan")[[".estimate"]],
-    54/86
+    77/86
   )
   expect_equal(
     sens(path_tbl)[[".estimate"]],
-    54/86
+    77/86
   )
   expect_equal(
     spec(pathology, truth = "pathology", estimate = "scan")[[".estimate"]],
-    231/258
+    162/258
   )
   expect_equal(
     spec(path_tbl)[[".estimate"]],
-    231/258
+    162/258
   )
   expect_equal(
     j_index(pathology, truth = "pathology", estimate = "scan")[[".estimate"]],
-    (231/258) + (54/86)  - 1
+    (162/258) + (77/86)  - 1
   )
   expect_equal(
     mcc(pathology, truth = "pathology", estimate = "scan")[[".estimate"]],
-    ((231 * 54) - (32 * 27)) / sqrt((231 + 32)*(231 + 27) * (54 + 32) * (54 + 27))
+    ((231 * 54) - (32 * 27)) / sqrt((231 + 32) * (231 + 27) * (54 + 32) * (54 + 27))
   )
 })
 
-
 test_that('global option is ignored in multiclass metrics', {
-  rlang::local_options(lifecycle_disable_warnings = TRUE)
+  rlang::local_options(lifecycle_verbosity = "quiet")
 
   expect_equal(
     rlang::with_options(


### PR DESCRIPTION
This PR hard deprecates the `yardstick.event first` global option. Setting it will no longer do anything, except throw a warning, reminding the user that setting the option doesn't do anything.

Revdep check was run on this PR and it didn't break anything.