### PR TITLE
No more expect_error()

### DIFF
--- a/tests/testthat/_snaps/aaa-new.md
+++ b/tests/testthat/_snaps/aaa-new.md
@@ -1,0 +1,17 @@
+# `fn` is validated
+
+    Code
+      new_class_metric(1, "maximize")
+    Condition
+      Error in `new_metric()`:
+      ! `fn` must be a function.
+
+# `direction` is validated
+
+    Code
+      new_class_metric(function() 1, "min")
+    Condition
+      Error in `new_metric()`:
+      ! `direction` must be one of "maximize", "minimize", or "zero", not "min".
+      i Did you mean "minimize"?
+

--- a/tests/testthat/_snaps/autoplot.md
+++ b/tests/testthat/_snaps/autoplot.md
@@ -1,0 +1,8 @@
+# Confusion Matrix - type argument
+
+    Code
+      ggplot2::autoplot(res, type = "wrong")
+    Condition
+      Error in `ggplot2::autoplot()`:
+      ! `type` must be one of "mosaic" or "heatmap", not "wrong".
+

--- a/tests/testthat/_snaps/error-handling.md
+++ b/tests/testthat/_snaps/error-handling.md
@@ -1,9 +1,17 @@
+# bad args
+
+    Code
+      sens(pathology, truth = "patholosgy", estimate = "scan")
+    Condition
+      Error in `sens()`:
+      ! Can't subset columns that don't exist.
+      x Column `patholosgy` doesn't exist.
+
 # `truth` should be factor
 
     Code
-      (expect_error(sens(df, truth, estimate)))
-    Output
-      <error/rlang_error>
+      sens(df, truth, estimate)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_factor_estimate()`:
@@ -12,9 +20,8 @@
 # At least 2 levels in truth
 
     Code
-      (expect_error(sens(df, truth, estimate)))
-    Output
-      <error/rlang_error>
+      sens(df, truth, estimate)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_binary_estimator()`:
@@ -23,9 +30,8 @@
 # Single character values are caught with correct errors
 
     Code
-      (expect_error(sens(pathology, "a", scan)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      sens(pathology, "a", scan)
+    Condition
       Error in `sens()`:
       ! Can't subset columns that don't exist.
       x Column `a` doesn't exist.
@@ -33,9 +39,8 @@
 # Bad unquoted input is caught
 
     Code
-      (expect_error(sens(pathology, !!bad, scan)))
-    Output
-      <error/vctrs_error_subscript_oob>
+      sens(pathology, !!bad, scan)
+    Condition
       Error in `sens()`:
       ! Can't subset columns that don't exist.
       x Column `a` doesn't exist.
@@ -43,9 +48,8 @@
 # Non-allowed estimator
 
     Code
-      (expect_error(sens(pathology, pathology, scan, estimator = "blah")))
-    Output
-      <error/rlang_error>
+      sens(pathology, pathology, scan, estimator = "blah")
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimator = finalize_estimator(.data[["pathology"]], estimator, name)`.
       Caused by error in `validate_estimator()`:
@@ -54,9 +58,8 @@
 # Bad estimator + truth combination
 
     Code
-      (expect_error(sens(hpc_cv, obs, pred, estimator = "binary")))
-    Output
-      <error/rlang_error>
+      sens(hpc_cv, obs, pred, estimator = "binary")
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_binary_estimator()`:
@@ -65,9 +68,8 @@
 # Bad estimator type
 
     Code
-      (expect_error(sens(hpc_cv, obs, pred, estimator = 1)))
-    Output
-      <error/rlang_error>
+      sens(hpc_cv, obs, pred, estimator = 1)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimator = finalize_estimator(.data[["obs"]], estimator, name)`.
       Caused by error in `validate_estimator()`:
@@ -76,9 +78,8 @@
 ---
 
     Code
-      (expect_error(sens(hpc_cv, obs, pred, estimator = c("1", "2"))))
-    Output
-      <error/rlang_error>
+      sens(hpc_cv, obs, pred, estimator = c("1", "2"))
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimator = finalize_estimator(.data[["obs"]], estimator, name)`.
       Caused by error in `validate_estimator()`:
@@ -87,9 +88,8 @@
 # Numeric matrix in numeric metric
 
     Code
-      (expect_error(rmse(solubility_test, a, prediction)))
-    Output
-      <error/rlang_error>
+      rmse(solubility_test, a, prediction)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_numeric_truth_numeric_estimate()`:
@@ -98,9 +98,8 @@
 ---
 
     Code
-      (expect_error(rmse(solubility_test, solubility, a)))
-    Output
-      <error/rlang_error>
+      rmse(solubility_test, solubility, a)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_numeric_truth_numeric_estimate()`:
@@ -109,9 +108,8 @@
 # Factors with non identical levels
 
     Code
-      (expect_error(sens(df, x, y)))
-    Output
-      <error/rlang_error>
+      sens(df, x, y)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_factor_estimate()`:
@@ -122,9 +120,8 @@
 # Multiple estimate columns for a binary metric
 
     Code
-      (expect_error(roc_auc(two_class_example, truth, Class1:Class2)))
-    Output
-      <error/rlang_error>
+      roc_auc(two_class_example, truth, Class1:Class2)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_matrix_estimate()`:
@@ -133,13 +130,20 @@
 # 1 estimate column for a multiclass metric
 
     Code
-      (expect_error(roc_auc(hpc_cv, obs, VF)))
-    Output
-      <error/rlang_error>
+      roc_auc(hpc_cv, obs, VF)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_matrix_estimate()`:
       ! The number of levels in `truth` (4) must match the number of columns supplied in `...` (1).
+
+# `truth` and `estimate` of different lengths
+
+    Code
+      rmse_vec(1:5, 1:6)
+    Condition
+      Error in `validate_numeric_truth_numeric_estimate()`:
+      ! Length of `truth` (5) and `estimate` (6) must match.
 
 # Missing arguments
 
@@ -156,4 +160,20 @@
     Condition
       Error in `sens()`:
       ! Must select at least one item.
+
+# Table with bad format
+
+    Code
+      sens(as.table(matrix(1:6, 2)))
+    Condition
+      Error:
+      ! the table must have nrow = ncol
+
+---
+
+    Code
+      sens(as.table(matrix(1:4, 2, dimnames = list(c("A", "B"), c("A", "C")))))
+    Condition
+      Error:
+      ! the table must the same groups in the same order
 

--- a/tests/testthat/_snaps/flatten.md
+++ b/tests/testthat/_snaps/flatten.md
@@ -1,0 +1,8 @@
+# flat tables
+
+    Code
+      yardstick:::flatten(three_class_tb[, 1:2])
+    Condition
+      Error in `yardstick:::flatten()`:
+      ! table must have equal dimensions
+

--- a/tests/testthat/_snaps/metric-tweak.md
+++ b/tests/testthat/_snaps/metric-tweak.md
@@ -1,0 +1,48 @@
+# cannot use protected names
+
+    Code
+      metric_tweak("f_meas2", f_meas, data = 2)
+    Condition
+      Error in `check_protected_names()`:
+      ! Arguments passed through `...` cannot be named any of: 'data', 'truth', 'estimate'.
+
+---
+
+    Code
+      metric_tweak("f_meas2", f_meas, truth = 2)
+    Condition
+      Error in `check_protected_names()`:
+      ! Arguments passed through `...` cannot be named any of: 'data', 'truth', 'estimate'.
+
+---
+
+    Code
+      metric_tweak("f_meas2", f_meas, estimate = 2)
+    Condition
+      Error in `check_protected_names()`:
+      ! Arguments passed through `...` cannot be named any of: 'data', 'truth', 'estimate'.
+
+# `name` must be a string
+
+    Code
+      metric_tweak(1, f_meas, beta = 2)
+    Condition
+      Error in `metric_tweak()`:
+      ! `.name` must be a string.
+
+# `fn` must be a metric function
+
+    Code
+      metric_tweak("foo", function() { }, beta = 2)
+    Condition
+      Error in `metric_tweak()`:
+      ! `.fn` must be a metric function.
+
+# All `...` must be named
+
+    Code
+      metric_tweak("foo", accuracy, 1)
+    Condition
+      Error in `metric_tweak()`:
+      ! All arguments passed through `...` must be named.
+

--- a/tests/testthat/_snaps/metrics.md
+++ b/tests/testthat/_snaps/metrics.md
@@ -1,3 +1,37 @@
+# bad args
+
+    Code
+      metrics(two_class_example, truth, Class1)
+    Condition
+      Error in `metric_set()`:
+      ! Failed to compute `accuracy()`.
+      Caused by error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_factor_truth_factor_estimate()`:
+      ! `estimate` should be a factor, not a `numeric`.
+
+---
+
+    Code
+      metrics(two_class_example, Class1, truth)
+    Condition
+      Error in `metric_set()`:
+      ! Failed to compute `rmse()`.
+      Caused by error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_numeric_truth_numeric_estimate()`:
+      ! `estimate` should be a numeric, not a `factor`.
+
+---
+
+    Code
+      metrics(three_class, "obs", "pred", setosa, versicolor)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_factor_truth_matrix_estimate()`:
+      ! The number of levels in `truth` (3) must match the number of columns supplied in `...` (2).
+
 # metrics() - `options` is deprecated
 
     Code
@@ -7,6 +41,29 @@
       The `options` argument of `metrics()` is deprecated as of yardstick 1.0.0.
       This argument no longer has any effect, and is being ignored.
       Use the pROC package directly if you need these features.
+
+# numeric metric sets
+
+    Code
+      metric_set(rmse, "x")
+    Condition
+      Error:
+      ! All inputs to `metric_set()` must be functions. These inputs are not: (2).
+
+# mixing bad metric sets
+
+    Code
+      metric_set(rmse, accuracy)
+    Condition
+      Error in `validate_function_class()`:
+      ! 
+      The combination of metric functions must be:
+      - only numeric metrics
+      - a mix of class metrics and class probability metrics
+      
+      The following metric function types are being mixed:
+      - numeric (rmse)
+      - class (accuracy)
 
 # print metric_set works
 
@@ -19,6 +76,50 @@
       1 rmse   numeric_metric minimize 
       2 rsq    numeric_metric maximize 
       3 ccc    numeric_metric maximize 
+
+# `metric_set()` errors contain env name for unknown functions (#128)
+
+    Code
+      metric_set(accuracy, foobar, sens, rlang::abort)
+    Condition
+      Error in `validate_function_class()`:
+      ! 
+      The combination of metric functions must be:
+      - only numeric metrics
+      - a mix of class metrics and class probability metrics
+      
+      The following metric function types are being mixed:
+      - class (accuracy, sens)
+      - other (foobar <test>, abort <namespace:rlang>)
+
+---
+
+    Code
+      metric_set(accuracy, foobar, sens, rlang::abort)
+    Condition
+      Error in `validate_function_class()`:
+      ! 
+      The combination of metric functions must be:
+      - only numeric metrics
+      - a mix of class metrics and class probability metrics
+      
+      The following metric function types are being mixed:
+      - class (accuracy, sens)
+      - other (foobar <test>, abort <namespace:rlang>)
+
+# `metric_set()` gives an informative error for a single non-metric function (#181)
+
+    Code
+      metric_set(foobar)
+    Condition
+      Error in `validate_function_class()`:
+      ! 
+      The combination of metric functions must be:
+      - only numeric metrics
+      - a mix of class metrics and class probability metrics
+      
+      The following metric function types are being mixed:
+      - other (foobar <test>)
 
 # propagates 'caused by' error message when specifying the wrong column name
 

--- a/tests/testthat/_snaps/num-huber_loss.md
+++ b/tests/testthat/_snaps/num-huber_loss.md
@@ -1,10 +1,8 @@
 # Huber Loss
 
     Code
-      (expect_error(huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = -
-        1)))
-    Output
-      <error/rlang_error>
+      huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `huber_loss_impl()`:
@@ -13,10 +11,8 @@
 ---
 
     Code
-      (expect_error(huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = c(
-        1, 2))))
-    Output
-      <error/rlang_error>
+      huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1, 2))
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `huber_loss_impl()`:

--- a/tests/testthat/_snaps/num-mase.md
+++ b/tests/testthat/_snaps/num-mase.md
@@ -1,0 +1,40 @@
+# Mean Absolute Scaled Error
+
+    Code
+      mase_vec(truth, pred, m = "x")
+    Condition
+      Error in `validate_m()`:
+      ! `m` must be a single positive integer value.
+
+---
+
+    Code
+      mase_vec(truth, pred, m = -1)
+    Condition
+      Error in `validate_m()`:
+      ! `m` must be a single positive integer value.
+
+---
+
+    Code
+      mase_vec(truth, pred, m = 1.5)
+    Condition
+      Error in `validate_m()`:
+      ! `m` must be a single positive integer value.
+
+---
+
+    Code
+      mase_vec(truth, pred, mae_train = -1)
+    Condition
+      Error in `validate_mae_train()`:
+      ! `mae_train` must be a single positive numeric value.
+
+---
+
+    Code
+      mase_vec(truth, pred, mae_train = "x")
+    Condition
+      Error in `validate_mae_train()`:
+      ! `mae_train` must be a single positive numeric value.
+

--- a/tests/testthat/_snaps/num-pseudo_huber_loss.md
+++ b/tests/testthat/_snaps/num-pseudo_huber_loss.md
@@ -1,10 +1,8 @@
 # Pseudo-Huber Loss
 
     Code
-      (expect_error(huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na",
-        delta = -1)))
-    Output
-      <error/rlang_error>
+      huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `huber_loss_pseudo_impl()`:
@@ -13,10 +11,8 @@
 ---
 
     Code
-      (expect_error(huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na",
-        delta = c(1, 2))))
-    Output
-      <error/rlang_error>
+      huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1, 2))
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `huber_loss_pseudo_impl()`:

--- a/tests/testthat/_snaps/prob-classification_cost.md
+++ b/tests/testthat/_snaps/prob-classification_cost.md
@@ -1,0 +1,100 @@
+# binary - requires 1 column of probabilities
+
+    Code
+      classification_cost(two_class_example, truth, Class1:Class2)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_factor_truth_matrix_estimate()`:
+      ! You are using a binary metric but have passed multiple columns to `...`.
+
+# costs must be a data frame with the right column names
+
+    Code
+      classification_cost(df, obs, A, costs = 1)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs` must be `NULL` or a data.frame.
+
+---
+
+    Code
+      classification_cost(df, obs, A, costs = data.frame())
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs` must be a data.frame with 3 columns.
+
+---
+
+    Code
+      classification_cost(df, obs, A, costs = data.frame(x = 1, y = 2, z = 3))
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs` must have columns: 'truth', 'estimate', and 'cost'.
+
+# costs$estimate must contain the right levels
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs$estimate` can only contain 'A', 'B'.
+
+# costs$truth must contain the right levels
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs$truth` can only contain 'A', 'B'.
+
+# costs$truth, costs$estimate, and costs$cost must have the right type
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs$truth` must be a character or factor column.
+
+---
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs$estimate` must be a character or factor column.
+
+---
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs$cost` must be a numeric column.
+
+# costs$truth and costs$estimate cannot contain duplicate pairs
+
+    Code
+      classification_cost(df, obs, A, costs = costs)
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `.estimate = fn(...)`.
+      Caused by error in `validate_costs()`:
+      ! `costs` cannot have duplicate 'truth' / 'estimate' combinations.
+

--- a/tests/testthat/_snaps/prob-roc_aunp.md
+++ b/tests/testthat/_snaps/prob-roc_aunp.md
@@ -1,9 +1,8 @@
 # AUNP errors on binary case
 
     Code
-      (expect_error(roc_aunp(two_class_example, truth, Class1)))
-    Output
-      <error/rlang_error>
+      roc_aunp(two_class_example, truth, Class1)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_matrix_estimate()`:

--- a/tests/testthat/_snaps/prob-roc_aunu.md
+++ b/tests/testthat/_snaps/prob-roc_aunu.md
@@ -1,9 +1,8 @@
 # AUNU errors on binary case
 
     Code
-      (expect_error(roc_aunu(two_class_example, truth, Class1)))
-    Output
-      <error/rlang_error>
+      roc_aunu(two_class_example, truth, Class1)
+    Condition
       Error in `dplyr::summarise()`:
       i In argument: `.estimate = fn(...)`.
       Caused by error in `validate_factor_truth_matrix_estimate()`:

--- a/tests/testthat/_snaps/prob-roc_curve.md
+++ b/tests/testthat/_snaps/prob-roc_curve.md
@@ -1,3 +1,28 @@
+# roc_curve() - error is thrown when missing events
+
+    Code
+      roc_curve_vec(no_event$truth, no_event$Class1)[[".estimate"]]
+    Condition
+      Error in `stop_roc_truth_no_event()`:
+      ! No event observations were detected in `truth` with event level 'Class1'.
+
+# roc_curve() - error is thrown when missing controls
+
+    Code
+      roc_curve_vec(no_control$truth, no_control$Class1)[[".estimate"]]
+    Condition
+      Error in `stop_roc_truth_no_control()`:
+      ! No control observations were detected in `truth` with control level 'Class2'.
+
+# roc_curve() - multiclass one-vs-all approach results in error
+
+    Code
+      roc_curve_vec(no_event$obs, as.matrix(dplyr::select(no_event, VF:L)))[[
+        ".estimate"]]
+    Condition
+      Error in `stop_roc_truth_no_control()`:
+      ! No control observations were detected in `truth` with control level '..other'.
+
 # roc_curve() - `options` is deprecated
 
     Code

--- a/tests/testthat/test-aaa-new.R
+++ b/tests/testthat/test-aaa-new.R
@@ -16,9 +16,15 @@ test_that("can create metric functions", {
 })
 
 test_that("`fn` is validated", {
-  expect_error(new_class_metric(1, "maximize"), "must be a function")
+  expect_snapshot(
+    error = TRUE,
+    new_class_metric(1, "maximize")
+  )
 })
 
 test_that("`direction` is validated", {
-  expect_error(new_class_metric(function() 1, "min"))
+  expect_snapshot(
+    error = TRUE,
+    new_class_metric(function() 1, "min")
+  )
 })

--- a/tests/testthat/test-autoplot.R
+++ b/tests/testthat/test-autoplot.R
@@ -34,7 +34,7 @@ hpc_cv2 <- dplyr::filter(hpc_cv, Resample %in% c("Fold06", "Fold07", "Fold08", "
 test_that("ROC Curve - two class", {
   res <- roc_curve(two_class_example, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -51,7 +51,7 @@ test_that("ROC Curve - two class", {
 test_that("ROC Curve - two class, with resamples", {
   res <- roc_curve(two_class_resamples, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -66,7 +66,7 @@ test_that("ROC Curve - two class, with resamples", {
 test_that("ROC Curve - multi class", {
   res <- roc_curve(hpc_cv2, obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -80,7 +80,7 @@ test_that("ROC Curve - multi class", {
 test_that("ROC Curve - multi class, with resamples", {
   res <- roc_curve(dplyr::group_by(hpc_cv2, Resample), obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -97,7 +97,7 @@ test_that("ROC Curve - multi class, with resamples", {
 test_that("PR Curve - two class", {
   res <- pr_curve(two_class_example, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -111,7 +111,7 @@ test_that("PR Curve - two class", {
 test_that("PR Curve - two class, with resamples", {
   res <- pr_curve(two_class_resamples, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -126,7 +126,7 @@ test_that("PR Curve - two class, with resamples", {
 test_that("PR Curve - multi class", {
   res <- pr_curve(hpc_cv2, obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -140,7 +140,7 @@ test_that("PR Curve - multi class", {
 test_that("PR Curve - multi class, with resamples", {
   res <- pr_curve(dplyr::group_by(hpc_cv2, Resample), obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -160,7 +160,7 @@ test_that("PR Curve - multi class, with resamples", {
 test_that("Gain Curve - two class", {
   res <- gain_curve(two_class_example, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -177,7 +177,7 @@ test_that("Gain Curve - two class", {
 test_that("Gain Curve - two class, with resamples", {
   res <- gain_curve(two_class_resamples, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -195,7 +195,7 @@ test_that("Gain Curve - two class, with resamples", {
 test_that("Gain Curve - multi class", {
   res <- gain_curve(hpc_cv2, obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -214,7 +214,7 @@ test_that("Gain Curve - multi class", {
 test_that("Gain Curve - multi class, with resamples", {
   res <- gain_curve(dplyr::group_by(hpc_cv2, Resample), obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -239,7 +239,7 @@ test_that("Gain Curve - multi class, with resamples", {
 test_that("Lift Curve - two class", {
   res <- lift_curve(two_class_example, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -262,7 +262,7 @@ test_that("Lift Curve - two class", {
 test_that("Lift Curve - two class, with resamples", {
   res <- lift_curve(two_class_resamples, truth, Class1)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -284,7 +284,7 @@ test_that("Lift Curve - two class, with resamples", {
 test_that("Lift Curve - multi class", {
   res <- lift_curve(hpc_cv2, obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -299,7 +299,7 @@ test_that("Lift Curve - multi class", {
 test_that("Lift Curve - multi class, with resamples", {
   res <- lift_curve(dplyr::group_by(hpc_cv2, Resample), obs, VF:L)
 
-  expect_error(.plot <- ggplot2::autoplot(res), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res))
   expect_s3_class(.plot, "gg")
 
   expect_true(".level" %in% colnames(res))
@@ -318,13 +318,16 @@ test_that("Lift Curve - multi class, with resamples", {
 test_that("Confusion Matrix - type argument", {
   res <- conf_mat(two_class_example, truth, predicted)
 
-  expect_error(.plot <- ggplot2::autoplot(res, type = "wrong"), "type")
+  expect_snapshot(
+    error = TRUE,
+    ggplot2::autoplot(res, type = "wrong")
+  )
 })
 
 test_that("Confusion Matrix - two class - heatmap", {
   res <- conf_mat(two_class_example, truth, predicted)
 
-  expect_error(.plot <- ggplot2::autoplot(res, type = "heatmap"), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res, type = "heatmap"))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -339,7 +342,7 @@ test_that("Confusion Matrix - multi class - heatmap", {
     dplyr::filter(Resample == "Fold01") %>%
     conf_mat(obs, pred)
 
-  expect_error(.plot <- ggplot2::autoplot(res, type = "heatmap"), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res, type = "heatmap"))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -358,13 +361,13 @@ test_that("Confusion Matrix - heatmap - can use non-standard labels (#157, #191)
   df <- dplyr::filter(hpc_cv, Resample == "Fold01")
 
   res1 <- conf_mat(df, obs, pred, dnn = c("Pred", "True"))
-  expect_error(p1 <- ggplot2::autoplot(res1, type = "heatmap"), NA)
+  expect_no_error(p1 <- ggplot2::autoplot(res1, type = "heatmap"))
   expect_identical(p1$labels$x, "True")
   expect_identical(p1$labels$y, "Pred")
 
   # Defaults are used when there are no names
   res2 <- conf_mat(df, obs, pred, dnn = NULL)
-  expect_error(p2 <- ggplot2::autoplot(res2, type = "heatmap"), NA)
+  expect_no_error(p2 <- ggplot2::autoplot(res2, type = "heatmap"))
   expect_identical(p2$labels$x, "Truth")
   expect_identical(p2$labels$y, "Prediction")
 })
@@ -373,13 +376,13 @@ test_that("Confusion Matrix - mosaic - can use non-standard labels (#191)", {
   df <- dplyr::filter(hpc_cv, Resample == "Fold01")
 
   res1 <- conf_mat(df, obs, pred, dnn = c("Pred", "True"))
-  expect_error(p1 <- ggplot2::autoplot(res1, type = "mosaic"), NA)
+  expect_no_error(p1 <- ggplot2::autoplot(res1, type = "mosaic"))
   expect_identical(p1$labels$x, "True")
   expect_identical(p1$labels$y, "Pred")
 
   # Defaults are used when there are no names
   res2 <- conf_mat(df, obs, pred, dnn = NULL)
-  expect_error(p2 <- ggplot2::autoplot(res2, type = "mosaic"), NA)
+  expect_no_error(p2 <- ggplot2::autoplot(res2, type = "mosaic"))
   expect_identical(p2$labels$x, "Truth")
   expect_identical(p2$labels$y, "Prediction")
 })
@@ -387,7 +390,7 @@ test_that("Confusion Matrix - mosaic - can use non-standard labels (#191)", {
 test_that("Confusion Matrix - two class - mosaic", {
   res <- conf_mat(two_class_example, truth, predicted)
 
-  expect_error(.plot <- ggplot2::autoplot(res, type = "mosaic"), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res, type = "mosaic"))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)
@@ -402,7 +405,7 @@ test_that("Confusion Matrix - multi class - mosaic", {
     dplyr::filter(Resample == "Fold01") %>%
     conf_mat(obs, pred)
 
-  expect_error(.plot <- ggplot2::autoplot(res, type = "mosaic"), NA)
+  expect_no_error(.plot <- ggplot2::autoplot(res, type = "mosaic"))
   expect_s3_class(.plot, "gg")
 
   .plot_data <- ggplot2::ggplot_build(.plot)

--- a/tests/testthat/test-error-handling.R
+++ b/tests/testthat/test-error-handling.R
@@ -1,73 +1,86 @@
 # Bad input --------------------------------------------------------------------
 
 test_that('bad args', {
-  expect_error(sens(pathology, truth = "patholosgy", estimate = "scan"))
+  expect_snapshot(
+    error = TRUE,
+    sens(pathology, truth = "patholosgy", estimate = "scan")
+  )
 })
 
 test_that("`truth` should be factor", {
   df <- dplyr::tibble(truth = 1, estimate = factor("A"))
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(df, truth, estimate)
-  )))
+  )
 })
 
 test_that("At least 2 levels in truth", {
   df <- dplyr::tibble(truth = factor("A"), estimate = factor("A"))
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(df, truth, estimate)
-  )))
+  )
 })
 
 test_that("Single character values are caught with correct errors", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(pathology, "a", scan)
-  )))
+  )
 })
 
 test_that("Bad unquoted input is caught", {
   bad <- rlang::expr(c("a", "b"))
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(pathology, !! bad, scan)
-  )))
+  )
 })
 
 # Bad estimator ----------------------------------------------------------------
 
 test_that("Non-allowed estimator", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(pathology, pathology, scan, estimator = "blah")
-  )))
+  )
 })
 
 test_that("Bad estimator + truth combination", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(hpc_cv, obs, pred, estimator = "binary")
-  )))
+  )
 })
 
 test_that("Bad estimator type", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(hpc_cv, obs, pred, estimator = 1)
-  )))
+  )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(hpc_cv, obs, pred, estimator = c("1", "2"))
-  )))
+  )
 })
 
 test_that("Numeric matrix in numeric metric", {
   solubility_test$a <- matrix(rep(1, nrow(solubility_test)), ncol = 1)
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     rmse(solubility_test, a, prediction)
-  )))
+  )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     rmse(solubility_test, solubility, a)
-  )))
+  )
 })
 
 test_that("Factors with non identical levels", {
@@ -76,27 +89,30 @@ test_that("Factors with non identical levels", {
     y = factor(c("a", "b", "b"))
   )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     sens(df, x, y)
-  )))
+  )
 })
 
 test_that("Multiple estimate columns for a binary metric", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     roc_auc(two_class_example, truth, Class1:Class2)
-  )))
+  )
 })
 
 test_that("1 estimate column for a multiclass metric", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     roc_auc(hpc_cv, obs, VF)
-  )))
+  )
 })
 
 test_that("`truth` and `estimate` of different lengths", {
-  expect_error(
-    rmse_vec(1:5, 1:6),
-    "Length of `truth` \\(5\\) and `estimate` \\(6\\) must match."
+  expect_snapshot(
+    error = TRUE,
+    rmse_vec(1:5, 1:6)
   )
 })
 
@@ -112,13 +128,13 @@ test_that("Missing arguments", {
 })
 
 test_that("Table with bad format", {
-  expect_error(
-    sens(as.table(matrix(1:6, 2))),
-    "the table must have nrow = ncol"
+  expect_snapshot(
+    error = TRUE,
+    sens(as.table(matrix(1:6, 2)))
   )
 
-  expect_error(
-    sens(as.table(matrix(1:4, 2, dimnames = list(c("A", "B"), c("A", "C"))))),
-    "the table must the same groups in the same order"
+  expect_snapshot(
+    error = TRUE,
+    sens(as.table(matrix(1:4, 2, dimnames = list(c("A", "B"), c("A", "C")))))
   )
 })

--- a/tests/testthat/test-flatten.R
+++ b/tests/testthat/test-flatten.R
@@ -12,5 +12,8 @@ test_that('flat tables', {
     c("cell_1_1", "cell_2_1", "cell_1_2", "cell_2_2")
   )
 
-  expect_error(yardstick:::flatten(three_class_tb[, 1:2]))
+  expect_snapshot(
+    error = TRUE,
+    yardstick:::flatten(three_class_tb[, 1:2])
+  )
 })

--- a/tests/testthat/test-metric-tweak.R
+++ b/tests/testthat/test-metric-tweak.R
@@ -120,19 +120,37 @@ test_that("can set `estimator` in the tweaked metric", {
 })
 
 test_that("cannot use protected names", {
-  expect_error(metric_tweak("f_meas2", f_meas, data = 2), "cannot be named")
-  expect_error(metric_tweak("f_meas2", f_meas, truth = 2), "cannot be named")
-  expect_error(metric_tweak("f_meas2", f_meas, estimate = 2), "cannot be named")
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak("f_meas2", f_meas, data = 2)
+  )
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak("f_meas2", f_meas, truth = 2)
+  )
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak("f_meas2", f_meas, estimate = 2)
+  )
 })
 
 test_that("`name` must be a string", {
-  expect_error(metric_tweak(1, f_meas, beta = 2), "must be a string")
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak(1, f_meas, beta = 2)
+  )
 })
 
 test_that("`fn` must be a metric function", {
-  expect_error(metric_tweak("foo", function() {}, beta = 2), "must be a metric function")
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak("foo", function() {}, beta = 2)
+  )
 })
 
 test_that("All `...` must be named", {
-  expect_error(metric_tweak("foo", accuracy, 1), "must be named")
+  expect_snapshot(
+    error = TRUE,
+    metric_tweak("foo", accuracy, 1)
+  )
 })

--- a/tests/testthat/test-metrics.R
+++ b/tests/testthat/test-metrics.R
@@ -35,13 +35,16 @@ test_that('correct metrics returned', {
 ###################################################################
 
 test_that('bad args', {
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     metrics(two_class_example, truth, Class1)
   )
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     metrics(two_class_example, Class1, truth)
   )
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     metrics(three_class, "obs", "pred", setosa, versicolor)
   )
 })
@@ -107,32 +110,31 @@ test_that('numeric metric sets', {
     reg_res_1
   )
   # ensure helpful messages are printed
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     metric_set(rmse, "x")
   )
 
   # Can mix class and class prob together
   mixed_set <- metric_set(accuracy, roc_auc)
-  expect_error(
-    mixed_set(two_class_example, truth, Class1, estimate = predicted),
-    NA
+  expect_no_error(
+    mixed_set(two_class_example, truth, Class1, estimate = predicted)
   )
 })
 
 test_that('mixing bad metric sets', {
-  expect_error(
+  expect_snapshot(
+    error = TRUE,
     metric_set(rmse, accuracy)
   )
 })
 
 test_that('can mix class and class prob metrics together', {
-  expect_error(
-    mixed_set <- metric_set(accuracy, roc_auc),
-    NA
+  expect_no_error(
+    mixed_set <- metric_set(accuracy, roc_auc)
   )
-  expect_error(
-    mixed_set(two_class_example, truth, Class1, estimate = predicted),
-    NA
+  expect_no_error(
+    mixed_set(two_class_example, truth, Class1, estimate = predicted)
   )
 })
 
@@ -242,13 +244,13 @@ test_that("`metric_set()` errors contain env name for unknown functions (#128)",
 
   rlang::fn_env(foobar) <- env
 
-  expect_error(
-    metric_set(accuracy, foobar, sens, rlang::abort),
-    "class [(]accuracy, sens[)]"
+  expect_snapshot(
+    error = TRUE,
+    metric_set(accuracy, foobar, sens, rlang::abort)
   )
-  expect_error(
-    metric_set(accuracy, foobar, sens, rlang::abort),
-    "other [(]foobar <test>, abort <namespace:rlang>[)]"
+  expect_snapshot(
+    error = TRUE,
+    metric_set(accuracy, foobar, sens, rlang::abort)
   )
 })
 
@@ -260,10 +262,9 @@ test_that("`metric_set()` gives an informative error for a single non-metric fun
   attr(env, "name") <- "test"
   rlang::fn_env(foobar) <- env
 
-  expect_error(
-    metric_set(foobar),
-    "other (foobar <test>)",
-    fixed = TRUE
+  expect_snapshot(
+    error = TRUE,
+    metric_set(foobar)
   )
 })
 

--- a/tests/testthat/test-num-huber_loss.R
+++ b/tests/testthat/test-num-huber_loss.R
@@ -28,14 +28,15 @@ test_that('Huber Loss', {
     }
   )
 
-
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
-  )))
+  )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1,2))
-  )))
+  )
 })
 
 test_that("Weighted results are working", {

--- a/tests/testthat/test-num-mase.R
+++ b/tests/testthat/test-num-mase.R
@@ -39,31 +39,30 @@ test_that('Mean Absolute Scaled Error', {
     known_mase_with_mae_train
   )
 
-  expect_error(
-    mase_vec(truth, pred, m = "x"),
-    "`m` must be a single positive integer value."
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(truth, pred, m = "x")
   )
 
-  expect_error(
-    mase_vec(truth, pred, m = -1),
-    "`m` must be a single positive integer value."
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(truth, pred, m = -1)
   )
 
-  expect_error(
-    mase_vec(truth, pred, m = 1.5),
-    "`m` must be a single positive integer value."
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(truth, pred, m = 1.5)
   )
 
-  expect_error(
-    mase_vec(truth, pred, mae_train = -1),
-    "`mae_train` must be a single positive numeric value."
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(truth, pred, mae_train = -1)
   )
 
-  expect_error(
-    mase_vec(truth, pred, mae_train = "x"),
-    "`mae_train` must be a single positive numeric value."
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(truth, pred, mae_train = "x")
   )
-
 })
 
 test_that("Weighted results are working", {

--- a/tests/testthat/test-num-pseudo_huber_loss.R
+++ b/tests/testthat/test-num-pseudo_huber_loss.R
@@ -18,13 +18,15 @@ test_that('Pseudo-Huber Loss', {
     }
   )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
-  )))
+  )
 
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1,2))
-  )))
+  )
 })
 
 test_that("Weighted results are working", {

--- a/tests/testthat/test-prob-classification_cost.R
+++ b/tests/testthat/test-prob-classification_cost.R
@@ -67,7 +67,10 @@ test_that("costs$truth can be factor", {
 })
 
 test_that("binary - requires 1 column of probabilities", {
-  expect_error(classification_cost(two_class_example, truth, Class1:Class2), "binary metric")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(two_class_example, truth, Class1:Class2)
+  )
 })
 
 # ------------------------------------------------------------------------------
@@ -172,9 +175,20 @@ test_that("costs must be a data frame with the right column names", {
     A = c(1, .80, .51)
   )
 
-  expect_error(classification_cost(df, obs, A, costs = 1), "`NULL` or a data.frame")
-  expect_error(classification_cost(df, obs, A, costs = data.frame()), "3 columns")
-  expect_error(classification_cost(df, obs, A, costs = data.frame(x = 1, y = 2, z = 3)), "'truth', 'estimate', and 'cost'")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = 1)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = data.frame())
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = data.frame(x = 1, y = 2, z = 3))
+  )
 })
 
 test_that("costs$estimate must contain the right levels", {
@@ -189,7 +203,10 @@ test_that("costs$estimate must contain the right levels", {
     "B",    "A",       3
   )
 
-  expect_error(classification_cost(df, obs, A, costs = costs), "can only contain 'A', 'B'")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
+  )
 })
 
 test_that("costs$truth must contain the right levels", {
@@ -204,7 +221,10 @@ test_that("costs$truth must contain the right levels", {
     "B",    "A",       3
   )
 
-  expect_error(classification_cost(df, obs, A, costs = costs), "can only contain 'A', 'B'")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
+  )
 })
 
 test_that("costs$truth, costs$estimate, and costs$cost must have the right type", {
@@ -218,21 +238,30 @@ test_that("costs$truth, costs$estimate, and costs$cost must have the right type"
     1,    "B",       2,
     2,    "A",       3
   )
-  expect_error(classification_cost(df, obs, A, costs = costs), "character or factor")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
+  )
 
   costs <- dplyr::tribble(
     ~truth, ~estimate, ~cost,
     "A",    1,       2,
     "B",    2,       3
   )
-  expect_error(classification_cost(df, obs, A, costs = costs), "character or factor")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
+  )
 
   costs <- dplyr::tribble(
     ~truth, ~estimate, ~cost,
     "A",    "B",       "1",
     "B",    "A",       "2"
   )
-  expect_error(classification_cost(df, obs, A, costs = costs), "numeric column")
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
+  )
 })
 
 test_that("costs$truth and costs$estimate cannot contain duplicate pairs", {
@@ -247,9 +276,9 @@ test_that("costs$truth and costs$estimate cannot contain duplicate pairs", {
     "A",    "B",       3
   )
 
-  expect_error(
-    classification_cost(df, obs, A, costs = costs),
-    "cannot have duplicate 'truth' / 'estimate' combinations"
+  expect_snapshot(
+    error = TRUE,
+    classification_cost(df, obs, A, costs = costs)
   )
 })
 

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -33,8 +33,8 @@ test_that("quasiquotation works", {
 
   tru <- as.name("truth")
 
-  expect_error(gain_curve(df, !!tru, estimate), regexp = NA)
-  expect_error(gain_curve(df, "truth", estimate), regexp = NA)
+  expect_no_error(gain_curve(df, !!tru, estimate))
+  expect_no_error(gain_curve(df, "truth", estimate))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-prob-lift_curve.R
+++ b/tests/testthat/test-prob-lift_curve.R
@@ -32,8 +32,8 @@ test_that("quasiquotation works", {
 
   tru <- as.name("truth")
 
-  expect_error(lift_curve(df, !!tru, estimate), regexp = NA)
-  expect_error(lift_curve(df, "truth", estimate), regexp = NA)
+  expect_no_error(lift_curve(df, !!tru, estimate))
+  expect_no_error(lift_curve(df, "truth", estimate))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -17,9 +17,10 @@ test_that("AUNP is equivalent to macro_weighted estimator with case weights", {
 })
 
 test_that("AUNP errors on binary case", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     roc_aunp(two_class_example, truth, Class1)
-  )))
+  )
 })
 
 test_that("AUNP results match mlr for soybean example", {

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -17,9 +17,10 @@ test_that("AUNU is equivalent to macro estimator with case weights", {
 })
 
 test_that("AUNU errors on binary case", {
-  expect_snapshot((expect_error(
+  expect_snapshot(
+    error = TRUE,
     roc_aunu(two_class_example, truth, Class1)
-  )))
+  )
 })
 
 test_that("AUNU results match mlr for soybean example", {

--- a/tests/testthat/test-prob-roc_curve.R
+++ b/tests/testthat/test-prob-roc_curve.R
@@ -121,30 +121,27 @@ test_that("Binary weighted results are the same as scikit-learn", {
 test_that("roc_curve() - error is thrown when missing events", {
   no_event <- dplyr::filter(two_class_example, truth == "Class2")
 
-  expect_error(
-    roc_curve_vec(no_event$truth, no_event$Class1)[[".estimate"]],
-    "No event observations were detected in `truth` with event level 'Class1'.",
-    class = "yardstick_error_roc_truth_no_event"
+  expect_snapshot(
+    error = TRUE,
+    roc_curve_vec(no_event$truth, no_event$Class1)[[".estimate"]]
   )
 })
 
 test_that("roc_curve() - error is thrown when missing controls", {
   no_control <- dplyr::filter(two_class_example, truth == "Class1")
 
-  expect_error(
-    roc_curve_vec(no_control$truth, no_control$Class1)[[".estimate"]],
-    "No control observations were detected in `truth` with control level 'Class2'.",
-    class = "yardstick_error_roc_truth_no_control"
+  expect_snapshot(
+    error = TRUE,
+    roc_curve_vec(no_control$truth, no_control$Class1)[[".estimate"]]
   )
 })
 
 test_that("roc_curve() - multiclass one-vs-all approach results in error", {
   no_event <- dplyr::filter(hpc_cv, Resample == "Fold01", obs == "VF")
 
-  expect_error(
-    roc_curve_vec(no_event$obs, as.matrix(dplyr::select(no_event, VF:L)))[[".estimate"]],
-    "No control observations were detected in `truth` with control level '..other'",
-    class = "yardstick_error_roc_truth_no_control"
+  expect_snapshot(
+    error = TRUE,
+    roc_curve_vec(no_event$obs, as.matrix(dplyr::select(no_event, VF:L)))[[".estimate"]]
   )
 })
 


### PR DESCRIPTION
This PR removes all uses of `expect_error()` with `expect_no_error()` or `expect_snapshot()`

to close https://github.com/tidymodels/yardstick/issues/335