### PR TITLE
Add conf_mat_impl()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@
   
 * Changed the default aspect ratio for PR curves to be 1.0. 
 
+* `conf_mat()` no longer throw errors listed as internal (#327).
+
 # yardstick 1.1.0
 
 * Emil Hvitfeldt is now the maintainer (#315).

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -176,6 +176,21 @@ conf_mat.grouped_df <- function(data,
   )
 }
 
+conf_mat_impl <- function(truth, estimate, case_weights) {
+  estimator <- "not binary"
+  check_class_metric(truth, estimate, case_weights, estimator)
+
+  if (length(levels(truth)) < 2) {
+    abort("`truth` must have at least 2 factor levels.")
+  }
+
+  yardstick_table(
+    truth = truth,
+    estimate = estimate,
+    case_weights = case_weights
+  )
+}
+
 #' @export
 conf_mat.table <- function(data, ...) {
   check_table(data)

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -102,19 +102,36 @@ conf_mat.data.frame <- function(data,
     warn_conf_mat_dots_deprecated()
   }
 
-  names <- names(data)
+  truth <- enquo(truth)
+  estimate <- enquo(estimate)
+  case_weights <- enquo(case_weights)
 
-  truth <- tidyselect::vars_pull(names, {{truth}})
+  truth <- yardstick_eval_select(
+    expr = truth,
+    data = data,
+    arg = "truth",
+    error_call = error_call
+  )
   truth <- data[[truth]]
 
-  estimate <- tidyselect::vars_pull(names, {{estimate}})
+  estimate <- yardstick_eval_select(
+    expr = estimate,
+    data = data,
+    arg = "estimate",
+    error_call = error_call
+  )
   estimate <- data[[estimate]]
 
-  case_weights <- enquo(case_weights)
   if (quo_is_null(case_weights)) {
     case_weights <- NULL
   } else {
-    case_weights <- tidyselect::vars_pull(names, !!case_weights)
+    case_weights <- yardstick_eval_select(
+      expr = case_weights,
+      data = data,
+      arg = "case_weights",
+      error_call = error_call
+    )
+
     case_weights <- data[[case_weights]]
   }
 
@@ -142,28 +159,40 @@ conf_mat.grouped_df <- function(data,
     warn_conf_mat_dots_deprecated()
   }
 
-  names <- names(data)
-
-  truth <- tidyselect::vars_pull(names, {{truth}})
-  truth <- as.name(truth)
-
-  estimate <- tidyselect::vars_pull(names, {{estimate}})
-  estimate <- as.name(estimate)
-
+  truth <- enquo(truth)
+  estimate <- enquo(estimate)
   case_weights <- enquo(case_weights)
-  if (quo_is_null(case_weights)) {
-    case_weights <- NULL
-  } else {
-    case_weights <- tidyselect::vars_pull(names, !!case_weights)
-    case_weights <- as.name(case_weights)
+
+  truth <- yardstick_eval_select(
+    expr = truth,
+    data = data,
+    arg = "truth",
+    error_call = error_call
+  )
+  estimate <- yardstick_eval_select(
+    expr = estimate,
+    data = data,
+    arg = "estimate",
+    error_call = error_call
+  )
+
+  if (!quo_is_null(case_weights)) {
+    case_weights <- yardstick_eval_select(
+      expr = case_weights,
+      data = data,
+      arg = "case_weights",
+      error_call = error_call
+    )
+
+    case_weights <- expr(.data[[!!case_weights]])
   }
 
   dplyr::summarise(
     data,
     conf_mat = {
       table <- yardstick_table(
-        truth = !!truth,
-        estimate = !!estimate,
+        truth = .data[[truth]],
+        estimate = .data[[estimate]],
         case_weights = !!case_weights
       )
 

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -109,16 +109,14 @@ conf_mat.data.frame <- function(data,
   truth <- yardstick_eval_select(
     expr = truth,
     data = data,
-    arg = "truth",
-    error_call = error_call
+    arg = "truth"
   )
   truth <- data[[truth]]
 
   estimate <- yardstick_eval_select(
     expr = estimate,
     data = data,
-    arg = "estimate",
-    error_call = error_call
+    arg = "estimate"
   )
   estimate <- data[[estimate]]
 
@@ -128,8 +126,7 @@ conf_mat.data.frame <- function(data,
     case_weights <- yardstick_eval_select(
       expr = case_weights,
       data = data,
-      arg = "case_weights",
-      error_call = error_call
+      arg = "case_weights"
     )
 
     case_weights <- data[[case_weights]]
@@ -166,22 +163,19 @@ conf_mat.grouped_df <- function(data,
   truth <- yardstick_eval_select(
     expr = truth,
     data = data,
-    arg = "truth",
-    error_call = error_call
+    arg = "truth"
   )
   estimate <- yardstick_eval_select(
     expr = estimate,
     data = data,
-    arg = "estimate",
-    error_call = error_call
+    arg = "estimate"
   )
 
   if (!quo_is_null(case_weights)) {
     case_weights <- yardstick_eval_select(
       expr = case_weights,
       data = data,
-      arg = "case_weights",
-      error_call = error_call
+      arg = "case_weights"
     )
 
     case_weights <- expr(.data[[!!case_weights]])

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -135,7 +135,7 @@ conf_mat.data.frame <- function(data,
     case_weights <- data[[case_weights]]
   }
 
-  table <- yardstick_table(
+  table <- conf_mat_impl(
     truth = truth,
     estimate = estimate,
     case_weights = case_weights
@@ -190,7 +190,7 @@ conf_mat.grouped_df <- function(data,
   dplyr::summarise(
     data,
     conf_mat = {
-      table <- yardstick_table(
+      table <- conf_mat_impl(
         truth = .data[[truth]],
         estimate = .data[[estimate]],
         case_weights = !!case_weights

--- a/tests/testthat/_snaps/conf_mat.md
+++ b/tests/testthat/_snaps/conf_mat.md
@@ -35,3 +35,68 @@
        9 Fold09   <conf_mat>
       10 Fold10   <conf_mat>
 
+# Errors are thrown correctly
+
+    Code
+      conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
+    Condition
+      Error in `validate_factor_truth_factor_estimate()`:
+      ! `truth` and `estimate` levels must be equivalent.
+      `truth`: virginica, versicolor, setosa
+      `estimate`: setosa, versicolor, virginica
+
+---
+
+    Code
+      conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
+    Condition
+      Error in `validate_factor_truth_factor_estimate()`:
+      ! `truth` and `estimate` levels must be equivalent.
+      `truth`: 1
+      `estimate`: setosa, versicolor, virginica
+
+---
+
+    Code
+      conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
+    Condition
+      Error in `conf_mat_impl()`:
+      ! `truth` must have at least 2 factor levels.
+
+# Errors are thrown correctly - grouped
+
+    Code
+      conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `conf_mat = { ... }`.
+      i In group 1: `pred = setosa`.
+      Caused by error in `validate_factor_truth_factor_estimate()`:
+      ! `truth` and `estimate` levels must be equivalent.
+      `truth`: virginica, versicolor, setosa
+      `estimate`: setosa, versicolor, virginica
+
+---
+
+    Code
+      conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `conf_mat = { ... }`.
+      i In group 1: `pred = setosa`.
+      Caused by error in `validate_factor_truth_factor_estimate()`:
+      ! `truth` and `estimate` levels must be equivalent.
+      `truth`: 1
+      `estimate`: setosa, versicolor, virginica
+
+---
+
+    Code
+      conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
+    Condition
+      Error in `dplyr::summarise()`:
+      i In argument: `conf_mat = { ... }`.
+      i In group 1: `pred = setosa`.
+      Caused by error in `conf_mat_impl()`:
+      ! `truth` must have at least 2 factor levels.
+

--- a/tests/testthat/_snaps/conf_mat.md
+++ b/tests/testthat/_snaps/conf_mat.md
@@ -100,3 +100,40 @@
       Caused by error in `conf_mat_impl()`:
       ! `truth` must have at least 2 factor levels.
 
+# conf_mat()'s errors when wrong things are passes
+
+    Code
+      conf_mat(two_class_example, not_truth, predicted)
+    Condition
+      Error in `conf_mat()`:
+      ! Can't subset columns that don't exist.
+      x Column `not_truth` doesn't exist.
+
+---
+
+    Code
+      conf_mat(two_class_example, truth, not_predicted)
+    Condition
+      Error in `conf_mat()`:
+      ! Can't subset columns that don't exist.
+      x Column `not_predicted` doesn't exist.
+
+---
+
+    Code
+      conf_mat(dplyr::group_by(two_class_example, truth), truth = not_truth,
+      estimate = predicted)
+    Condition
+      Error in `conf_mat()`:
+      ! Can't subset columns that don't exist.
+      x Column `not_truth` doesn't exist.
+
+---
+
+    Code
+      conf_mat(dplyr::group_by(two_class_example, truth), truth = truth, estimate = not_predicted)
+    Condition
+      Error in `conf_mat()`:
+      ! Can't subset columns that don't exist.
+      x Column `not_predicted` doesn't exist.
+

--- a/tests/testthat/test-conf_mat.R
+++ b/tests/testthat/test-conf_mat.R
@@ -260,3 +260,33 @@ test_that('Errors are thrown correctly - grouped', {
   )
 })
 
+test_that("conf_mat()'s errors when wrong things are passes", {
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(two_class_example, not_truth, predicted)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(two_class_example, truth, not_predicted)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(
+      dplyr::group_by(two_class_example, truth),
+      truth = not_truth,
+      estimate = predicted
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(
+      dplyr::group_by(two_class_example, truth),
+      truth = truth,
+      estimate = not_predicted
+    )
+  )
+})

--- a/tests/testthat/test-conf_mat.R
+++ b/tests/testthat/test-conf_mat.R
@@ -212,3 +212,51 @@ test_that("`...` is deprecated with a warning", {
   hpc_cv <- dplyr::group_by(hpc_cv, Resample)
   expect_snapshot(conf_mat(hpc_cv, obs, pred, foo = 1))
 })
+
+test_that('Errors are thrown correctly', {
+  lst <- data_three_class()
+  three_class <- lst$three_class
+  three_class$obs_rev <- three_class$obs
+  levels(three_class$obs_rev) <- rev(levels(three_class$obs))
+  three_class$onelevel <- factor(1)
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
+  )
+})
+
+test_that('Errors are thrown correctly - grouped', {
+  lst <- data_three_class()
+  three_class <- lst$three_class
+  three_class$obs_rev <- three_class$obs
+  levels(three_class$obs_rev) <- rev(levels(three_class$obs))
+  three_class$onelevel <- factor(1)
+  three_class <- dplyr::group_by(three_class, pred)
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
+  )
+})
+


### PR DESCRIPTION
This PR aims to close https://github.com/tidymodels/yardstick/issues/327, close https://github.com/tidymodels/yardstick/issues/314, and close https://github.com/tidymodels/yardstick/issues/234.

Users were getting internal errors when using `conf_mat()` incorrectly. This happened because the `conf_mat()` functions called `yardstick_table()` directly without doing any input checking.

This PR fixes that by adding the function `conf_mat_impl()` that is used internally in `conf_mat.data.frame()` and `conf_mat.grouped_df()` such that we can do input checking correctly.