### PR TITLE
No more startup message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,8 @@
 
 * `conf_mat()` no longer throw errors listed as internal (#327).
 
+* Removed start-up message about `event_level` argument.
+
 # yardstick 1.1.0
 
 * Emil Hvitfeldt is now the maintainer (#315).

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -44,20 +44,6 @@ utils::globalVariables(
   invisible()
 }
 
-# On attach msg ----------------------------------------------------------------
-
-.onAttach <- function(libname, pkgname) {
-  msg <- paste0(
-    "For binary classification, ",
-    "the first factor level is assumed to be the event.\n",
-    "Use the argument `event_level = \"second\"` to alter this as needed."
-  )
-
-  packageStartupMessage(msg)
-
-  invisible()
-}
-
 # Dynamic reg helper -----------------------------------------------------------
 
 # vctrs/register-s3.R


### PR DESCRIPTION
# This PR

``` r
library(yardstick)
```

<sup>Created on 2023-02-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

# Main

``` r
library(yardstick)
#> For binary classification, the first factor level is assumed to be the event.
#> Use the argument `event_level = "second"` to alter this as needed.
```

<sup>Created on 2023-02-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>