### PR TITLE
Add trapezoidal_rule() helper function

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -462,3 +462,18 @@ yardstick_truth_table <- function(truth, ..., case_weights = NULL) {
 
   out
 }
+
+trapezoidal_rule <- function(x, y) {
+  n_x <- length(x)
+  n_y <- length(y)
+
+  if (n_x != n_y) {
+    rlang::abort(
+      paste0("`x` (",n_x, ") and `y` (",n_y, ") must be same length."),
+      .internal = TRUE
+    )
+  }
+
+  delta <- diff(x)
+  sum(delta * (y[-1] + y[-n_y])) / 2
+}

--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -152,3 +152,13 @@
       Error in `weighted_quantile()`:
       ! `probabilities` can't be missing.
 
+# trapezoidal_rule errors when lengths of x and y differs
+
+    Code
+      trapezoidal_rule(1:6, 1:7)
+    Condition
+      Error in `trapezoidal_rule()`:
+      ! `x` (6) and `y` (7) must be same length.
+      i This is an internal error that was detected in the yardstick package.
+        Please report it at <https://github.com/tidymodels/yardstick/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -351,3 +351,41 @@ test_that("`probabilities` can't be missing", {
   expect_snapshot(error = TRUE, weighted_quantile(1, 1, NA))
 })
 
+# ------------------------------------------------------------------------------
+# trapezoidal_rule()
+
+test_that("trapezoidal_rule gives correct answers", {
+  expect_identical(
+    trapezoidal_rule(1:4, rep(3, 4)),
+    9
+  )
+
+  expect_identical(
+    trapezoidal_rule(c(1, 11), c(1, 6)),
+    (11 - 1) * (6 - 1) / 2 + 1 * (11 - 1)
+  )
+})
+
+test_that("trapezoidal_rule returns 0 with when input has length < 2", {
+  expect_identical(
+    trapezoidal_rule(1, 1),
+    0
+  )
+
+  expect_identical(
+    trapezoidal_rule(10, 26),
+    0
+  )
+
+  expect_identical(
+    trapezoidal_rule(numeric(), numeric()),
+    0
+  )
+})
+
+test_that("trapezoidal_rule errors when lengths of x and y differs", {
+  expect_snapshot(
+    error = TRUE,
+    trapezoidal_rule(1:6, 1:7)
+  )
+})


### PR DESCRIPTION
This PR adds the internal function `trapezoidal_rule()`, that will be used in the future metrics `integrated_brier_score()` and `survival_roc_auc()`