### PR TITLE
speed up `roc_curve_survival_impl()`

### DIFF
--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -114,8 +114,8 @@ roc_curve_survival_impl <- function(truth,
   res <- dplyr::tibble(.threshold = sort(unique(c(0, 1, estimate))))
   event_time <- .extract_surv_time(truth)
   delta <- .extract_surv_status(truth)
-  obs_time_le_time <- ifelse(event_time <= eval_time, 1, 0)
-  obs_time_gt_time <- ifelse(event_time > eval_time, 1, 0)
+  obs_time_le_time <- event_time <= eval_time
+  obs_time_gt_time <- event_time > eval_time
   n <- length(estimate)
   multiplier <- delta / (n * censoring_weights)
 
@@ -139,7 +139,7 @@ sensitivity_uno_2007 <- function(threshold,
                                  obs_time_le_time,
                                  multiplier) {
   # Since the "marker" X is the survival prob, X <= C means an event
-  prob_le_thresh <- ifelse(prob_surv <= threshold, 1, 0)
+  prob_le_thresh <- prob_surv <= threshold
   numer <- sum(obs_time_le_time * prob_le_thresh * multiplier, na.rm = TRUE)
   denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
   numer / denom
@@ -148,7 +148,7 @@ sensitivity_uno_2007 <- function(threshold,
 specificity_naive <- function(threshold, prob_surv,
                               obs_time_gt_time) {
   # Since the "marker" X is the survival prob, X > C means no event
-  prob_gt_thresh <- ifelse(prob_surv > threshold, 1, 0)
+  prob_gt_thresh <- prob_surv > threshold
   numer <- sum(obs_time_gt_time * prob_gt_thresh, na.rm = TRUE)
   denom <- sum(obs_time_gt_time, na.rm = TRUE)
   numer / denom

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -124,11 +124,16 @@ roc_curve_survival_impl <- function(truth,
   sensitivity_denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
   specificity_denom <- sum(obs_time_gt_time, na.rm = TRUE)
 
-  sensitivity <- data.frame(x = obs_time_le_time, y = multiplier)
-  sensitivity <- split(sensitivity, estimate)
+  data_df <- data.frame(
+    le_time = obs_time_le_time,
+    ge_time = obs_time_gt_time,
+    multiplier = multiplier
+  )
+  data_split <- split(data_df, estimate)
+
   sensitivity <- vapply(
-    sensitivity,
-    function(x) sum(x$x * x$y, na.rm = TRUE),
+    data_split,
+    function(x) sum(x$le_time * x$multiplier, na.rm = TRUE),
     FUN.VALUE = numeric(1)
   )
   sensitivity <- cumsum(sensitivity)
@@ -136,11 +141,9 @@ roc_curve_survival_impl <- function(truth,
   sensitivity <- c(0, sensitivity, 1)
   res$sensitivity <- sensitivity
 
-  specificity <- split(obs_time_gt_time, estimate)
   specificity <- vapply(
-    specificity,
-    sum,
-    na.rm = TRUE,
+    data_split,
+    function(x) sum(x$gt_time, na.rm = TRUE),
     FUN.VALUE = numeric(1)
   )
   specificity <- cumsum(specificity)

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -119,11 +119,14 @@ roc_curve_survival_impl <- function(truth,
   n <- length(estimate)
   multiplier <- delta / (n * censoring_weights)
 
+  sensitivity_denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
+  specificity_denom <- sum(obs_time_gt_time, na.rm = TRUE)
+
   res$sensitivity <- vapply(
     res$.threshold,
     sensitivity_uno_2007,
     FUN.VALUE = numeric(1),
-    estimate, obs_time_le_time, multiplier
+    estimate, obs_time_le_time, multiplier, sensitivity_denom
   )
   res$specificity <- vapply(
     res$.threshold,
@@ -137,20 +140,20 @@ roc_curve_survival_impl <- function(truth,
 sensitivity_uno_2007 <- function(threshold,
                                  prob_surv,
                                  obs_time_le_time,
-                                 multiplier) {
+                                 multiplier,
+                                 denom) {
   # Since the "marker" X is the survival prob, X <= C means an event
   prob_le_thresh <- prob_surv <= threshold
   numer <- sum(obs_time_le_time * prob_le_thresh * multiplier, na.rm = TRUE)
-  denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
   numer / denom
 }
 
 specificity_naive <- function(threshold, prob_surv,
-                              obs_time_gt_time) {
+                              obs_time_gt_time,
+                              denom) {
   # Since the "marker" X is the survival prob, X > C means no event
   prob_gt_thresh <- prob_surv > threshold
   numer <- sum(obs_time_gt_time * prob_gt_thresh, na.rm = TRUE)
-  denom <- sum(obs_time_gt_time, na.rm = TRUE)
   numer / denom
 }
 

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -132,7 +132,7 @@ roc_curve_survival_impl <- function(truth,
     res$.threshold,
     specificity_naive,
     FUN.VALUE = numeric(1),
-    estimate, obs_time_gt_time
+    estimate, obs_time_gt_time, specificity_denom
   )
   res
 }

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -111,9 +111,17 @@ roc_curve_survival_impl <- function(truth,
                                     estimate,
                                     censoring_weights,
                                     eval_time) {
-  res <- dplyr::tibble(.threshold = sort(unique(c(0, 1, estimate))))
   event_time <- .extract_surv_time(truth)
   delta <- .extract_surv_status(truth)
+
+  new_order <- vctrs::vec_order(estimate)
+  event_time <- event_time[new_order]
+  delta <- delta[new_order]
+  estimate <- estimate[new_order]
+  censoring_weights <- censoring_weights[new_order]
+  eval_time <- eval_time[new_order]
+
+  res <- dplyr::tibble(.threshold = sort(unique(c(0, 1, estimate))))
   obs_time_le_time <- event_time <= eval_time
   obs_time_gt_time <- event_time > eval_time
   n <- length(estimate)

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -114,14 +114,8 @@ roc_curve_survival_impl <- function(truth,
   event_time <- .extract_surv_time(truth)
   delta <- .extract_surv_status(truth)
 
-  new_order <- vctrs::vec_order(estimate)
-  event_time <- event_time[new_order]
-  delta <- delta[new_order]
-  estimate <- estimate[new_order]
-  censoring_weights <- censoring_weights[new_order]
-  eval_time <- eval_time[new_order]
+  res <- dplyr::tibble(.threshold = sort(unique(c(0, estimate, 1))))
 
-  res <- dplyr::tibble(.threshold = unique(c(0, estimate, 1)))
   obs_time_le_time <- event_time <= eval_time
   obs_time_gt_time <- event_time > eval_time
   n <- length(estimate)

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -121,7 +121,7 @@ roc_curve_survival_impl <- function(truth,
   censoring_weights <- censoring_weights[new_order]
   eval_time <- eval_time[new_order]
 
-  res <- dplyr::tibble(.threshold = sort(unique(c(0, 1, estimate))))
+  res <- dplyr::tibble(.threshold = unique(c(0, estimate, 1)))
   obs_time_le_time <- event_time <= eval_time
   obs_time_gt_time <- event_time > eval_time
   n <- length(estimate)

--- a/R/surv-roc_survival_curve.R
+++ b/R/surv-roc_survival_curve.R
@@ -124,30 +124,30 @@ roc_curve_survival_impl <- function(truth,
   sensitivity_denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
   specificity_denom <- sum(obs_time_gt_time, na.rm = TRUE)
 
-  new_sensitivity <- data.frame(x = obs_time_le_time, y = multiplier)
-  new_sensitivity <- split(new_sensitivity, estimate)
-  new_sensitivity <- vapply(
-    new_sensitivity,
+  sensitivity <- data.frame(x = obs_time_le_time, y = multiplier)
+  sensitivity <- split(sensitivity, estimate)
+  sensitivity <- vapply(
+    sensitivity,
     function(x) sum(x$x * x$y, na.rm = TRUE),
     FUN.VALUE = numeric(1)
   )
-  new_sensitivity <- cumsum(new_sensitivity)
-  new_sensitivity <- new_sensitivity / sensitivity_denom
-  new_sensitivity <- c(0, new_sensitivity, 1)
-  res$sensitivity <- new_sensitivity
+  sensitivity <- cumsum(sensitivity)
+  sensitivity <- sensitivity / sensitivity_denom
+  sensitivity <- c(0, sensitivity, 1)
+  res$sensitivity <- sensitivity
 
-  new_specificity <- split(obs_time_gt_time, estimate)
-  new_specificity <- vapply(
-    new_specificity,
+  specificity <- split(obs_time_gt_time, estimate)
+  specificity <- vapply(
+    specificity,
     sum,
     na.rm = TRUE,
     FUN.VALUE = numeric(1)
   )
-  new_specificity <- cumsum(new_specificity)
-  new_specificity <- new_specificity / specificity_denom
-  new_specificity <- c(0, new_specificity, 1)
-  new_specificity <- 1 - new_specificity
-  res$specificity <- new_specificity
+  specificity <- cumsum(specificity)
+  specificity <- specificity / specificity_denom
+  specificity <- c(0, specificity, 1)
+  specificity <- 1 - specificity
+  res$specificity <- specificity
 
   res
 }


### PR DESCRIPTION
Before this PR, I saw:

``` r
bench::mark(
  yardstick:::roc_curve_survival_impl(
    truth = rr_churn_data$surv,
    estimate = rr_churn_data$surv_prob,
    censoring_weights = rr_churn_data$ipcw,
    eval_time = rr_churn_data$times
  )
)
#> # A tibble: 1 × 13
#>   expression    min median itr/s…¹ mem_a…² gc/se…³ n_itr  n_gc total…⁴ result
#>   <list>     <bch:> <bch:>   <dbl> <bch:b>   <dbl> <int> <dbl> <bch:t> <list>
#> 1 <chr [1]>   50.6s  50.6s  0.0198   133GB    13.7     1   694   50.6s <tibble>
#> # … with 3 more variables: memory <list>, time <list>, gc <list>, and
#> #   abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`, ⁴​total_time
#> # ℹ Use `colnames()` to see all variable names
```

With this PR:

``` r
#> # A tibble: 1 × 13
#>   expression    min median itr/s…¹ mem_a…² gc/se…³ n_itr  n_gc total…⁴ result
#>   <bch:expr> <bch:> <bch:>   <dbl> <bch:b>   <dbl> <int> <dbl> <bch:t> <list>
#> 1 total       7.59s  7.59s   0.132  12.7GB    40.1     1   304   7.59s <tibble>
#> # … with 3 more variables: memory <list>, time <list>, gc <list>, and
#> #   abbreviated variable names ¹​`itr/sec`, ²​mem_alloc, ³​`gc/sec`, ⁴​total_time
#> # ℹ Use `colnames()` to see all variable names
```

@EmilHvitfeldt mentioned there could be a `sort()`ing trick we could use for the `<=` comparison that might drive this down further. :)