### PR TITLE
Survival metric set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,8 @@
   
 * Time-Dependent ROC AUC estimation for right-censored data can now be 
   calculated with `roc_auc_survival()`.
+  
+* `metric_set()` can now be used with a combination of dynamic and static survival metrics.
 
 # yardstick 1.1.0
 

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -611,6 +611,7 @@ validate_function_class <- function(fns) {
     "\nThe combination of metric functions must be:\n",
     "- only numeric metrics\n",
     "- a mix of class metrics and class probability metrics\n\n",
+    "- a mix of dynamic and static survival metrics\n\n",
     "The following metric function types are being mixed:\n",
     fn_pastable
   ))

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -250,7 +250,7 @@ metric_set <- function(...) {
   } else if(fn_cls %in% c("prob_metric", "class_metric")) {
     make_prob_class_metric_function(fns)
   } else if(fn_cls %in% c("dynamic_survival_metric", "static_survival_metric")) {
-    make_dynamic_survival_metric_function(fns)
+    make_survival_metric_function(fns)
   } else {
     abort(paste0(
       "Internal error: `validate_function_class()` should have ",
@@ -455,7 +455,7 @@ make_numeric_metric_function <- function(fns) {
   metric_function
 }
 
-make_dynamic_survival_metric_function <- function(fns) {
+make_survival_metric_function <- function(fns) {
   metric_function <- function(data,
                               truth,
                               estimate,
@@ -495,7 +495,7 @@ make_dynamic_survival_metric_function <- function(fns) {
   }
 
   class(metric_function) <- c(
-    "dynamic_survival_metric_set",
+    "survival_metric_set",
     "metric_set",
     class(metric_function)
   )

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -249,7 +249,7 @@ metric_set <- function(...) {
     make_numeric_metric_function(fns)
   } else if(fn_cls %in% c("prob_metric", "class_metric")) {
     make_prob_class_metric_function(fns)
-  } else if(fn_cls %in% "dynamic_survival_metric") {
+  } else if(fn_cls %in% c("dynamic_survival_metric", "static_survival_metric")) {
     make_dynamic_survival_metric_function(fns)
   } else {
     abort(paste0(
@@ -540,7 +540,7 @@ validate_function_class <- function(fns) {
     return(invisible(fns))
   }
   valid_cls <- c("class_metric", "prob_metric", "numeric_metric",
-                 "dynamic_survival_metric")
+                 "dynamic_survival_metric", "static_survival_metric")
 
   if (n_unique == 1L) {
     if (fn_cls_unique %in% valid_cls) {
@@ -553,6 +553,13 @@ validate_function_class <- function(fns) {
   if (n_unique == 2) {
     if (fn_cls_unique[1] %in% c("class_metric", "prob_metric") &&
         fn_cls_unique[2] %in% c("class_metric", "prob_metric")) {
+      return(invisible(fns))
+    }
+
+    if (fn_cls_unique[1] %in% c("dynamic_survival_metric",
+                                "static_survival_metric") &&
+        fn_cls_unique[2] %in% c("dynamic_survival_metric",
+                                "static_survival_metric")) {
       return(invisible(fns))
     }
   }

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -128,6 +128,7 @@ metrics.data.frame <- function(data,
 #' All functions must be either:
 #' - Only numeric metrics
 #' - A mix of class metrics or class prob metrics
+#' - A mix of dynamic and static survival metrics
 #'
 #' For instance, `rmse()` can be used with `mae()` because they
 #' are numeric metrics, but not with `accuracy()` because it is a classification
@@ -159,12 +160,27 @@ metrics.data.frame <- function(data,
 #'   event_level = yardstick_event_level(),
 #'   case_weights = NULL
 #' )
+#'
+#' # Dynamic / static survival metric set signature:
+#' fn(
+#'   data,
+#'   truth,
+#'   estimate,
+#'   censoring_weights,
+#'   eval_time,
+#'   na_rm = TRUE,
+#'   case_weights = NULL,
+#'   ...
+#' )
 #' ```
 #'
 #' When mixing class and class prob metrics, pass in the hard predictions
 #' (the factor column) as the named argument `estimate`, and the soft
 #' predictions (the class probability columns) as bare column names or
 #' `tidyselect` selectors to `...`.
+#'
+#' When mixing dynamic and static survival metrics, `censoring_weights` and
+#' `eval_time` is only needed when dynamic metrics are included in the set.
 #'
 #' @examples
 #' library(dplyr)

--- a/man/metric_set.Rd
+++ b/man/metric_set.Rd
@@ -18,6 +18,7 @@ All functions must be either:
 \itemize{
 \item Only numeric metrics
 \item A mix of class metrics or class prob metrics
+\item A mix of dynamic and static survival metrics
 }
 
 For instance, \code{rmse()} can be used with \code{mae()} because they
@@ -49,12 +50,27 @@ fn(
   event_level = yardstick_event_level(),
   case_weights = NULL
 )
+
+# Dynamic / static survival metric set signature:
+fn(
+  data,
+  truth,
+  estimate,
+  censoring_weights,
+  eval_time,
+  na_rm = TRUE,
+  case_weights = NULL,
+  ...
+)
 }\if{html}{\out{</div>}}
 
 When mixing class and class prob metrics, pass in the hard predictions
 (the factor column) as the named argument \code{estimate}, and the soft
 predictions (the class probability columns) as bare column names or
 \code{tidyselect} selectors to \code{...}.
+
+When mixing dynamic and static survival metrics, \code{censoring_weights} and
+\code{eval_time} is only needed when dynamic metrics are included in the set.
 }
 \examples{
 library(dplyr)

--- a/tests/testthat/_snaps/metrics.md
+++ b/tests/testthat/_snaps/metrics.md
@@ -60,6 +60,8 @@
       - only numeric metrics
       - a mix of class metrics and class probability metrics
       
+      - a mix of dynamic and static survival metrics
+      
       The following metric function types are being mixed:
       - numeric (rmse)
       - class (accuracy)
@@ -87,6 +89,8 @@
       - only numeric metrics
       - a mix of class metrics and class probability metrics
       
+      - a mix of dynamic and static survival metrics
+      
       The following metric function types are being mixed:
       - class (accuracy, sens)
       - other (foobar <test>, abort <namespace:rlang>)
@@ -102,6 +106,8 @@
       - only numeric metrics
       - a mix of class metrics and class probability metrics
       
+      - a mix of dynamic and static survival metrics
+      
       The following metric function types are being mixed:
       - class (accuracy, sens)
       - other (foobar <test>, abort <namespace:rlang>)
@@ -116,6 +122,8 @@
       The combination of metric functions must be:
       - only numeric metrics
       - a mix of class metrics and class probability metrics
+      
+      - a mix of dynamic and static survival metrics
       
       The following metric function types are being mixed:
       - other (foobar <test>)

--- a/tests/testthat/test-metrics.R
+++ b/tests/testthat/test-metrics.R
@@ -147,6 +147,15 @@ test_that('dynamic survival metric sets', {
   )
 })
 
+test_that('can mix dynamic and static survival metric together', {
+  expect_no_error(
+    mixed_set <- metric_set(brier_survival, concordance_survival)
+  )
+  expect_no_error(
+    mixed_set(lung_surv, surv_obj, .pred_survival, ipcw, .time)
+  )
+})
+
 test_that("can supply `event_level` even with metrics that don't use it", {
   df <- two_class_example
 


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/398

``` r
library(yardstick)
library(survival)

survival_metrics <- metric_set(
  brier_survival_integrated,
  roc_auc_survival,
  concordance_survival
)

lung_surv |>
  survival_metrics(
    truth = surv_obj,
    estimate = .pred_survival,
    censoring_weights = ipcw,
    eval_time = .time
  )
#> # A tibble: 3 × 3
#>   .metric                   .estimator .estimate
#>   <chr>                     <chr>          <dbl>
#> 1 brier_survival_integrated standard       0.156
#> 2 roc_auc_survival          standard       0.867
#> 3 concordance_survival      standard       0.542

survival_metrics <- metric_set(
  brier_survival,
  brier_survival_integrated,
  roc_auc_survival,
  concordance_survival
)

lung_surv |>
  survival_metrics(
    truth = surv_obj,
    estimate = .pred_survival,
    censoring_weights = ipcw,
    eval_time = .time
  )
#> # A tibble: 6 × 4
#>   .time .metric                   .estimator .estimate
#>   <dbl> <chr>                     <chr>          <dbl>
#> 1   100 brier_survival            standard      0.163 
#> 2   500 brier_survival            standard      0.237 
#> 3  1000 brier_survival            standard      0.0676
#> 4    NA brier_survival_integrated standard      0.156 
#> 5    NA roc_auc_survival          standard      0.867 
#> 6    NA concordance_survival      standard      0.542
```

<sup>Created on 2023-03-20 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>