### PR TITLE
Update naming evaluation time

### DIFF
--- a/R/surv-brier.R
+++ b/R/surv-brier.R
@@ -80,7 +80,7 @@ brier_survival.data.frame <- function(data,
                                       na_rm = TRUE,
                                       case_weights = NULL,
                                       ...) {
-  data <- dplyr::group_by(data, {{eval_time}})
+  data <- dplyr::group_by(data, .eval_time = {{eval_time}})
 
   dynamic_survival_metric_summarizer(
     name = "brier_survival",

--- a/R/template.R
+++ b/R/template.R
@@ -406,6 +406,14 @@ dynamic_survival_metric_summarizer <- function(name,
     )
   )
 
+  if (".eval_time" %in% names(out)) {
+    out <- dplyr::relocate(
+      out,
+      dplyr::any_of(".eval_time"),
+      .after = dplyr::last_col()
+    )
+  }
+
   dplyr::as_tibble(out)
 }
 

--- a/tests/testthat/test-surv-brier.R
+++ b/tests/testthat/test-surv-brier.R
@@ -1,4 +1,21 @@
 test_that('case weights', {
+  lung_surv <- data_lung_surv()
+
+  brier_res <- brier_survival(
+    data = lung_surv,
+    truth = surv_obj,
+    estimate = .pred_survival,
+    censoring_weights = ipcw,
+    eval_time = .time
+  )
+
+  expect_equal(
+    names(brier_res),
+    c(".metric", ".estimator", ".estimate", ".eval_time")
+  )
+})
+
+test_that('case weights', {
   lung_surv <- data_lung_surv() %>% dplyr::filter(.time == 100)
   lung_surv$case_wts <- rep(2, nrow(lung_surv))
 

--- a/tests/testthat/test-surv-brier_integrated.R
+++ b/tests/testthat/test-surv-brier_integrated.R
@@ -9,7 +9,7 @@ test_that('brier_survival_integrated calculations', {
     eval_time = .time
   ) %>%
     dplyr::summarise(
-      .estimate = yardstick:::auc(.time, .estimate) / max(.time)
+      .estimate = yardstick:::auc(.eval_time, .estimate) / max(.eval_time)
     )
 
   brier_integrated_res <- brier_survival_integrated(
@@ -40,7 +40,7 @@ test_that('case weights', {
     eval_time = .time
   ) %>%
     dplyr::summarise(
-      .estimate = yardstick:::auc(.time, .estimate) / max(.time)
+      .estimate = yardstick:::auc(.eval_time, .estimate) / max(.eval_time)
     )
 
   brier_integrated_res <- brier_survival_integrated(


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/397

Now all arguments related to evaluation time uses `eval_time` and all output uses the name `.eval_time`.