### PR TITLE
Make omitted errors better

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,8 @@
   
 * `metric_set()` can now be used with a combination of dynamic and static survival metrics.
 
+* Error messages now show what user-facing function was called instead of internal function. (#348)
+
 # yardstick 1.1.0
 
 * Emil Hvitfeldt is now the maintainer (#315).

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
   
 * `metric_set()` can now be used with a combination of dynamic and static survival metrics.
 
-* Error messages now show what user-facing function was called instead of internal function. (#348)
+* Error messages now show what user-facing function was called (#348). 
 
 # yardstick 1.1.0
 

--- a/R/check-metric.R
+++ b/R/check-metric.R
@@ -42,9 +42,9 @@ check_numeric_metric <- function(truth, estimate, case_weights) {
 
 #' @rdname check_metric
 #' @export
-check_class_metric <- function(truth, estimate, case_weights, estimator) {
+check_class_metric <- function(truth, estimate, case_weights, estimator, call = caller_env()) {
   validate_case_weights(case_weights, size = length(truth))
-  validate_factor_truth_factor_estimate(truth, estimate)
+  validate_factor_truth_factor_estimate(truth, estimate, call = call)
   validate_binary_estimator(truth, estimator)
 }
 

--- a/R/check-metric.R
+++ b/R/check-metric.R
@@ -6,6 +6,8 @@
 #' `dplyr::summarise()`. These functions perform checks on the inputs in
 #' accordance with the type of metric that is used.
 #'
+#' @inheritParams rlang::args_error_context
+#'
 #' @param truth The realized vector of `truth`.
 #'   - For `check_numeric_metric()`, a numeric vector.
 #'   - For `check_class_metric()`, a factor.
@@ -35,39 +37,54 @@ NULL
 
 #' @rdname check_metric
 #' @export
-check_numeric_metric <- function(truth, estimate, case_weights) {
-  validate_case_weights(case_weights, size = length(truth))
-  validate_numeric_truth_numeric_estimate(truth, estimate)
+check_numeric_metric <- function(truth,
+                                 estimate,
+                                 case_weights,
+                                 call = caller_env()) {
+  validate_case_weights(case_weights, size = length(truth), call = call)
+  validate_numeric_truth_numeric_estimate(truth, estimate, call = call)
 }
 
 #' @rdname check_metric
 #' @export
-check_class_metric <- function(truth, estimate, case_weights, estimator, call = caller_env()) {
-  validate_case_weights(case_weights, size = length(truth))
+check_class_metric <- function(truth,
+                               estimate,
+                               case_weights,
+                               estimator,
+                               call = caller_env()) {
+  validate_case_weights(case_weights, size = length(truth), call = call)
   validate_factor_truth_factor_estimate(truth, estimate, call = call)
-  validate_binary_estimator(truth, estimator)
+  validate_binary_estimator(truth, estimator, call = call)
 }
 
 #' @rdname check_metric
 #' @export
-check_prob_metric <- function(truth, estimate, case_weights, estimator) {
-  validate_case_weights(case_weights, size = length(truth))
-  validate_factor_truth_matrix_estimate(truth, estimate, estimator)
-  validate_binary_estimator(truth, estimator)
+check_prob_metric <- function(truth,
+                              estimate,
+                              case_weights,
+                              estimator,
+                              call = caller_env()) {
+  validate_case_weights(case_weights, size = length(truth), call = call)
+  validate_factor_truth_matrix_estimate(truth, estimate, estimator, call = call)
+  validate_binary_estimator(truth, estimator, call = call)
 }
 
 #' @rdname check_metric
 #' @export
 check_dynamic_survival_metric <- function(truth,
                                           estimate,
-                                          case_weights) {
-  validate_surv_truth_list_estimate(truth, estimate)
-  validate_case_weights(case_weights, size = nrow(truth))
+                                          case_weights,
+                                          call = caller_env()) {
+  validate_surv_truth_list_estimate(truth, estimate, call = call)
+  validate_case_weights(case_weights, size = nrow(truth), call = call)
 }
 
 #' @rdname check_metric
 #' @export
-check_static_survival_metric <- function(truth, estimate, case_weights) {
-  validate_case_weights(case_weights, size = nrow(truth))
-  validate_surv_truth_numeric_estimate(truth, estimate)
+check_static_survival_metric <- function(truth,
+                                         estimate,
+                                         case_weights,
+                                         call = call()) {
+  validate_case_weights(case_weights, size = nrow(truth), call = call)
+  validate_surv_truth_numeric_estimate(truth, estimate, call = call)
 }

--- a/R/check-metric.R
+++ b/R/check-metric.R
@@ -84,7 +84,7 @@ check_dynamic_survival_metric <- function(truth,
 check_static_survival_metric <- function(truth,
                                          estimate,
                                          case_weights,
-                                         call = call()) {
+                                         call = caller_env()) {
   validate_case_weights(case_weights, size = nrow(truth), call = call)
   validate_surv_truth_numeric_estimate(truth, estimate, call = call)
 }

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -146,8 +146,8 @@ kap_table_impl <- function(data, weighting) {
   1 - n_disagree / n_chance
 }
 
-make_weighting_matrix <- function(weighting, n_levels) {
-  validate_weighting(weighting)
+make_weighting_matrix <- function(weighting, n_levels, call = caller_env()) {
+  validate_weighting(weighting, call = call)
 
   if (is_no_weighting(weighting)) {
     # [n_levels x n_levels], 0 on diagonal, 1 on off-diagonal
@@ -173,9 +173,9 @@ make_weighting_matrix <- function(weighting, n_levels) {
 
 # ------------------------------------------------------------------------------
 
-validate_weighting <- function(x) {
+validate_weighting <- function(x, call = caller_env()) {
   if (!rlang::is_string(x)) {
-    abort("`weighting` must be a string.")
+    abort("`weighting` must be a string.", call = call)
   }
 
   ok <- is_no_weighting(x) ||
@@ -183,7 +183,7 @@ validate_weighting <- function(x) {
     is_quadratic_weighting(x)
 
   if (!ok) {
-    abort("`weighting` must be 'none', 'linear', or 'quadratic'.")
+    abort("`weighting` must be 'none', 'linear', or 'quadratic'.", call = call)
   }
 
   invisible(x)

--- a/R/estimator-helpers.R
+++ b/R/estimator-helpers.R
@@ -90,28 +90,40 @@ get_weights <- function(data, estimator) {
 #' @seealso [metric-summarizers] [check_metric] [yardstick_remove_missing]
 #'
 #' @export
-finalize_estimator <- function(x, estimator = NULL, metric_class = "default") {
+finalize_estimator <- function(x,
+                               estimator = NULL,
+                               metric_class = "default",
+                               call = caller_env()) {
   metric_dispatcher <- make_dummy(metric_class)
-  finalize_estimator_internal(metric_dispatcher, x, estimator)
+  finalize_estimator_internal(metric_dispatcher, x, estimator, call = call)
 }
 
 #' @rdname developer-helpers
 #' @param metric_dispatcher A simple dummy object with the class provided to
 #' `metric_class`. This is created and passed along for you.
 #' @export
-finalize_estimator_internal <- function(metric_dispatcher, x, estimator) {
+finalize_estimator_internal <- function(metric_dispatcher,
+                                        x,
+                                        estimator,
+                                        call = caller_env()) {
   UseMethod("finalize_estimator_internal")
 }
 
-finalize_estimator_internal.default <- function(metric_dispatcher, x, estimator) {
-  finalize_estimator_default(x, estimator)
+finalize_estimator_internal.default <- function(metric_dispatcher,
+                                                x,
+                                                estimator,
+                                                call = caller_env()) {
+  finalize_estimator_default(x, estimator, call = call)
 }
 
 # Accuracy, Kappa, Mean Log Loss, and MCC have natural multiclass extensions.
 # Additionally, they all produce the same results regardless of which level
 # is considered the "event". Because of this, the user cannot set the estimator,
 # and it should only be "binary" or "multiclass"
-finalize_estimator_internal.accuracy <- function(metric_dispatcher, x, estimator) {
+finalize_estimator_internal.accuracy <- function(metric_dispatcher,
+                                                 x,
+                                                 estimator,
+                                                 call = caller_env()) {
   if (is_multiclass(x)) {
     "multiclass"
   }
@@ -139,7 +151,10 @@ finalize_estimator_internal.pr_curve   <- finalize_estimator_internal.accuracy
 
 # Hand Till method is the "best" multiclass extension to me
 # because it is immune to class imbalance like binary roc_auc
-finalize_estimator_internal.roc_auc <- function(metric_dispatcher, x, estimator) {
+finalize_estimator_internal.roc_auc <- function(metric_dispatcher,
+                                                x,
+                                                estimator,
+                                                call = caller_env()) {
 
   validate_estimator(
     estimator = estimator,
@@ -160,7 +175,10 @@ finalize_estimator_internal.roc_auc <- function(metric_dispatcher, x, estimator)
 }
 
 # PR AUC and Gain Capture don't have micro methods currently
-finalize_estimator_internal.pr_auc <- function(metric_dispatcher, x, estimator) {
+finalize_estimator_internal.pr_auc <- function(metric_dispatcher,
+                                               x,
+                                               estimator,
+                                               call = caller_env()) {
 
   validate_estimator(
     estimator = estimator,
@@ -184,33 +202,43 @@ finalize_estimator_internal.gain_capture <- finalize_estimator_internal.pr_auc
 
 # Default ----------------------------------------------------------------------
 
-finalize_estimator_default <- function(x, estimator) {
+finalize_estimator_default <- function(x, estimator, call = caller_env()) {
   if (!is.null(estimator)) {
-    validate_estimator(estimator)
+    validate_estimator(estimator, call = call)
     return(estimator)
   }
   UseMethod("finalize_estimator_default")
 }
 
-finalize_estimator_default.default <- function(x, estimator) {
+finalize_estimator_default.default <- function(x,
+                                               estimator,
+                                               call = caller_env()) {
   "binary"
 }
 
-finalize_estimator_default.matrix <- function(x, estimator) {
+finalize_estimator_default.matrix <- function(x,
+                                              estimator,
+                                              call = caller_env()) {
   "macro"
 }
 
 # Covers all numeric metric functions
-finalize_estimator_default.numeric <- function(x, estimator) {
+finalize_estimator_default.numeric <- function(x,
+                                               estimator,
+                                               call = caller_env()) {
   "standard"
 }
 
 # Covers all dynamic survival functions
-finalize_estimator_default.Surv <- function(x, estimator) {
+finalize_estimator_default.Surv <- function(x,
+                                            estimator,
+                                            call = caller_env()) {
   "standard"
 }
 
-finalize_estimator_default.table <- function(x, estimator) {
+finalize_estimator_default.table <- function(x,
+                                             estimator,
+                                             call = caller_env()) {
   if (is_multiclass(x)) {
     "macro"
   }
@@ -219,7 +247,9 @@ finalize_estimator_default.table <- function(x, estimator) {
   }
 }
 
-finalize_estimator_default.factor <- function(x, estimator) {
+finalize_estimator_default.factor <- function(x,
+                                              estimator,
+                                              call = caller_env()) {
   if (is_multiclass(x)) {
     "macro"
   }

--- a/R/estimator-helpers.R
+++ b/R/estimator-helpers.R
@@ -77,6 +77,8 @@ get_weights <- function(data, estimator) {
 #'
 #' @rdname developer-helpers
 #'
+#' @inheritParams rlang::args_error_context
+#'
 #' @param metric_class A single character of the name of the metric to autoselect
 #' the estimator for. This should match the method name created for
 #' `finalize_estimator_internal()`.

--- a/R/num-huber_loss.R
+++ b/R/num-huber_loss.R
@@ -80,15 +80,16 @@ huber_loss_vec <- function(truth,
 huber_loss_impl <- function(truth,
                             estimate,
                             delta,
-                            case_weights) {
+                            case_weights,
+                            call = caller_env()) {
   # Weighted Huber Loss implementation confirmed against matlab:
   # https://www.mathworks.com/help/deeplearning/ref/dlarray.huber.html
 
   if (!rlang::is_bare_numeric(delta, n = 1L)) {
-    abort("`delta` must be a single numeric value.")
+    abort("`delta` must be a single numeric value.", call = call)
   }
   if (!(delta >= 0)) {
-    abort("`delta` must be a positive value.")
+    abort("`delta` must be a positive value.", call = call)
   }
 
   a <- truth - estimate

--- a/R/num-mase.R
+++ b/R/num-mase.R
@@ -112,12 +112,13 @@ mase_impl <- function(truth,
                       estimate,
                       m = 1L,
                       mae_train = NULL,
-                      case_weights = NULL) {
-  validate_m(m)
-  validate_mae_train(mae_train)
+                      case_weights = NULL,
+                      call = caller_env()) {
+  validate_m(m, call = call)
+  validate_mae_train(mae_train, call = call)
 
   if (is.null(mae_train)) {
-    validate_truth_m(truth, m)
+    validate_truth_m(truth, m, call = call)
   }
 
   # Use out-of-sample snaive if mae_train is not provided
@@ -138,21 +139,21 @@ mase_impl <- function(truth,
   out
 }
 
-validate_m <- function(m) {
+validate_m <- function(m, call = caller_env()) {
   abort_msg <- "`m` must be a single positive integer value."
 
   if (!rlang::is_integerish(m, n = 1L)) {
-    abort(abort_msg)
+    abort(abort_msg, call = call)
   }
 
   if (!(m > 0)) {
-    abort(abort_msg)
+    abort(abort_msg, call = call)
   }
 
   invisible(m)
 }
 
-validate_mae_train <- function(mae_train) {
+validate_mae_train <- function(mae_train, call = caller_env()) {
   if (is.null(mae_train)) {
     return(invisible(mae_train))
   }
@@ -161,22 +162,22 @@ validate_mae_train <- function(mae_train) {
   abort_msg <- "`mae_train` must be a single positive numeric value."
 
   if (!is_single_numeric) {
-    abort(abort_msg)
+    abort(abort_msg, call = call)
   }
 
   if (!(mae_train > 0)) {
-    abort(abort_msg)
+    abort(abort_msg, call = call)
   }
 
   invisible(mae_train)
 }
 
-validate_truth_m <- function(truth, m) {
+validate_truth_m <- function(truth, m, call = caller_env()) {
   if (length(truth) <= m) {
     abort(paste0(
       "`truth` must have a length greater than `m` ",
       "to compute the out-of-sample naive mean absolute error."
-    ))
+    ), call = call)
   }
 
   invisible(truth)

--- a/R/num-pseudo_huber_loss.R
+++ b/R/num-pseudo_huber_loss.R
@@ -84,12 +84,13 @@ huber_loss_pseudo_vec <- function(truth,
 huber_loss_pseudo_impl <- function(truth,
                                    estimate,
                                    delta,
-                                   case_weights) {
+                                   case_weights,
+                                   call = caller_env()) {
   if (!rlang::is_bare_numeric(delta, n = 1L)) {
-    abort("`delta` must be a single numeric value.")
+    abort("`delta` must be a single numeric value.", call = call)
   }
   if (!(delta >= 0)) {
-    abort("`delta` must be a positive value.")
+    abort("`delta` must be a positive value.", call = call)
   }
 
   a <- truth - estimate

--- a/R/prob-brier.R
+++ b/R/prob-brier.R
@@ -148,10 +148,6 @@ brier_ind <- function(truth, estimate, case_weights = NULL) {
 
 # When `truth` is a factor
 brier_factor <- function(truth, estimate, case_weights = NULL) {
-  if (!is.factor(truth)) {
-    rlang::abort("'truth' should be a factor.")
-  }
-
   inds <- hardhat::fct_encode_one_hot(truth)
 
   brier_ind(inds, estimate, case_weights)

--- a/R/template.R
+++ b/R/template.R
@@ -81,7 +81,7 @@ numeric_metric_summarizer <- function(name,
                                       case_weights = NULL,
                                       fn_options = list(),
                                       error_call = caller_env()) {
-  rlang::check_dots_empty()
+  rlang::check_dots_empty(call = error_call)
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -175,7 +175,7 @@ class_metric_summarizer <- function(name,
                                     case_weights = NULL,
                                     fn_options = list(),
                                     error_call = caller_env()) {
-  rlang::check_dots_empty()
+  rlang::check_dots_empty(call = error_call)
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -547,7 +547,7 @@ static_survival_metric_summarizer <- function(name,
                                               case_weights = NULL,
                                               fn_options = list(),
                                               error_call = caller_env()) {
-  rlang::check_dots_empty()
+  rlang::check_dots_empty(call = error_call)
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -757,7 +757,7 @@ yardstick_eval_select <- function(expr,
                                   arg,
                                   ...,
                                   error_call = caller_env()) {
-  check_dots_empty()
+  check_dots_empty(call = error_call)
 
   out <- tidyselect::eval_select(
     expr = expr,

--- a/R/template.R
+++ b/R/template.R
@@ -222,7 +222,7 @@ class_metric_summarizer <- function(name,
         name
       ),
       .estimate = rlang::inject(
-        fn(
+        withCallingHandlers(fn(
           truth = group_truth,
           estimate = group_estimate,
           case_weights = group_case_weights,
@@ -230,8 +230,11 @@ class_metric_summarizer <- function(name,
           !!! spliceable_argument(estimator, "estimator"),
           !!! spliceable_argument(event_level, "event_level"),
           !!! fn_options
-        )
-      )
+        ), error = function(cnd) {
+          cnd$call <- NULL
+          abort(class = "yardstick_metric_error", parent = cnd, call = error_call)
+        }
+      ))
     )
 
     out[[i]] <- tibble::new_tibble(elt_out)

--- a/R/template.R
+++ b/R/template.R
@@ -131,7 +131,8 @@ numeric_metric_summarizer <- function(name,
       .metric = name,
       .estimator = finalize_estimator(
         group_truth,
-        metric_class = name
+        metric_class = name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -225,7 +226,8 @@ class_metric_summarizer <- function(name,
       .estimator = finalize_estimator(
         group_truth,
         estimator,
-        name
+        name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -316,7 +318,8 @@ prob_metric_summarizer <- function(name,
       .estimator = finalize_estimator(
         group_truth,
         estimator,
-        name
+        name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -407,7 +410,8 @@ curve_metric_summarizer <- function(name,
       .estimator = finalize_estimator(
         group_truth,
         estimator,
-        name
+        name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -496,7 +500,8 @@ dynamic_survival_metric_summarizer <- function(name,
       .metric = name,
       .estimator = finalize_estimator(
         group_truth,
-        metric_class = name
+        metric_class = name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -592,7 +597,8 @@ static_survival_metric_summarizer <- function(name,
       .metric = name,
       .estimator = finalize_estimator(
         group_truth,
-        metric_class = name
+        metric_class = name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(
@@ -678,7 +684,8 @@ curve_survival_metric_summarizer <- function(name,
       .metric = name,
       .estimator = finalize_estimator(
         group_truth,
-        metric_class = name
+        metric_class = name,
+        call = error_call
       ),
       .estimate = rlang::inject(
         withCallingHandlers(

--- a/R/template.R
+++ b/R/template.R
@@ -134,12 +134,18 @@ numeric_metric_summarizer <- function(name,
         metric_class = name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!!fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!!fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )
@@ -222,19 +228,22 @@ class_metric_summarizer <- function(name,
         name
       ),
       .estimate = rlang::inject(
-        withCallingHandlers(fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!! spliceable_argument(estimator, "estimator"),
-          !!! spliceable_argument(event_level, "event_level"),
-          !!! fn_options
-        ), error = function(cnd) {
-          cnd$call <- NULL
-          abort(class = "yardstick_metric_error", parent = cnd, call = error_call)
-        }
-      ))
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!! spliceable_argument(estimator, "estimator"),
+            !!! spliceable_argument(event_level, "event_level"),
+            !!! fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
+        )
+      )
     )
 
     out[[i]] <- tibble::new_tibble(elt_out)
@@ -310,14 +319,20 @@ prob_metric_summarizer <- function(name,
         name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!! spliceable_argument(estimator, "estimator"),
-          !!! spliceable_argument(event_level, "event_level"),
-          !!! fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!! spliceable_argument(estimator, "estimator"),
+            !!! spliceable_argument(event_level, "event_level"),
+            !!! fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )
@@ -395,14 +410,20 @@ curve_metric_summarizer <- function(name,
         name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!! spliceable_argument(estimator, "estimator"),
-          !!! spliceable_argument(event_level, "event_level"),
-          !!! fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!! spliceable_argument(estimator, "estimator"),
+            !!! spliceable_argument(event_level, "event_level"),
+            !!! fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )
@@ -478,12 +499,18 @@ dynamic_survival_metric_summarizer <- function(name,
         metric_class = name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!!fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!!fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )
@@ -568,12 +595,18 @@ static_survival_metric_summarizer <- function(name,
         metric_class = name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!!fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!!fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )
@@ -648,12 +681,18 @@ curve_survival_metric_summarizer <- function(name,
         metric_class = name
       ),
       .estimate = rlang::inject(
-        fn(
-          truth = group_truth,
-          estimate = group_estimate,
-          case_weights = group_case_weights,
-          na_rm = na_rm,
-          !!! fn_options
+        withCallingHandlers(
+          fn(
+            truth = group_truth,
+            estimate = group_estimate,
+            case_weights = group_case_weights,
+            na_rm = na_rm,
+            !!! fn_options
+          ),
+          error = function(cnd) {
+            cnd$call <- error_call
+            cnd_signal(cnd)
+          }
         )
       )
     )

--- a/R/validation.R
+++ b/R/validation.R
@@ -36,7 +36,9 @@ validate_numeric_truth_numeric_estimate <- function(truth, estimate) {
   }
 }
 
-validate_factor_truth_factor_estimate <- function(truth, estimate) {
+validate_factor_truth_factor_estimate <- function(truth,
+                                                  estimate,
+                                                  call = caller_env()) {
   if (is_class_pred(truth)) {
     truth <- as_factor_from_class_pred(truth)
   }
@@ -47,14 +49,14 @@ validate_factor_truth_factor_estimate <- function(truth, estimate) {
     cls <- class(truth)[[1]]
     abort(paste0(
       "`truth` should be a factor, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (!is.factor(estimate)) {
     cls <- class(estimate)[[1]]
     abort(paste0(
       "`estimate` should be a factor, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   lvls_t <- levels(truth)
@@ -68,7 +70,8 @@ validate_factor_truth_factor_estimate <- function(truth, estimate) {
         "`truth` and `estimate` levels must be equivalent.\n",
         "`truth`: ",    lvls_t, "\n",
         "`estimate`: ", lvls_e, "\n"
-      )
+      ),
+      call = call
     )
   }
 
@@ -79,7 +82,8 @@ validate_factor_truth_factor_estimate <- function(truth, estimate) {
     abort(paste0(
       "Length of `truth` (", n_truth, ") ",
       "and `estimate` (", n_estimate, ") must match."
-    ))
+    ),
+    call = call)
   }
 }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -1,28 +1,30 @@
-validate_numeric_truth_numeric_estimate <- function(truth, estimate) {
+validate_numeric_truth_numeric_estimate <- function(truth,
+                                                    estimate,
+                                                    call = caller_env()) {
   if (!is.numeric(truth)) {
     cls <- class(truth)[[1]]
     abort(paste0(
       "`truth` should be a numeric, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (!is.numeric(estimate)) {
     cls <- class(estimate)[[1]]
     abort(paste0(
       "`estimate` should be a numeric, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (is.matrix(estimate)) {
     abort(paste0(
       "`estimate` should be a numeric vector, not a numeric matrix."
-    ))
+    ), call = call)
   }
 
   if (is.matrix(truth)) {
     abort(paste0(
       "`truth` should be a numeric vector, not a numeric matrix."
-    ))
+    ), call = call)
   }
 
   n_truth <- length(truth)
@@ -32,7 +34,7 @@ validate_numeric_truth_numeric_estimate <- function(truth, estimate) {
     abort(paste0(
       "Length of `truth` (", n_truth, ") ",
       "and `estimate` (", n_estimate, ") must match."
-    ))
+    ), call = call)
   }
 }
 
@@ -87,7 +89,10 @@ validate_factor_truth_factor_estimate <- function(truth,
   }
 }
 
-validate_factor_truth_matrix_estimate <- function(truth, estimate, estimator) {
+validate_factor_truth_matrix_estimate <- function(truth,
+                                                  estimate,
+                                                  estimator,
+                                                  call = caller_env()) {
   if (is_class_pred(truth)) {
     truth <- as_factor_from_class_pred(truth)
   }
@@ -96,21 +101,21 @@ validate_factor_truth_matrix_estimate <- function(truth, estimate, estimator) {
     cls <- class(truth)[[1]]
     abort(paste0(
       "`truth` should be a factor, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (estimator == "binary") {
     if (is.matrix(estimate)) {
       abort(paste0(
         "You are using a binary metric but have passed multiple columns to `...`."
-      ))
+      ), call = call)
     }
 
     if (!is.numeric(estimate)) {
       cls <- class(estimate)[[1]]
       abort(paste0(
         "`estimate` should be a numeric vector, not a `", cls, "` vector."
-      ))
+      ), call = call)
     }
 
     n_lvls <- length(levels(truth))
@@ -118,7 +123,7 @@ validate_factor_truth_matrix_estimate <- function(truth, estimate, estimator) {
       abort(paste0(
         "`estimator` is binary, only two class `truth` factors are allowed. ",
         "A factor with ", n_lvls, " levels was provided."
-      ))
+      ), call = call)
     }
   } else {
     n_lvls <- length(levels(truth))
@@ -133,35 +138,37 @@ validate_factor_truth_matrix_estimate <- function(truth, estimate, estimator) {
       abort(paste0(
         "The number of levels in `truth` (", n_lvls, ") ",
         "must match the number of columns supplied in `...` (", n_cols, ")."
-      ))
+      ), call = call)
     }
 
     if (!is.numeric(as.vector(estimate))) {
       cls <- class(as.vector(estimate))[[1]]
       abort(paste0(
         "The columns supplied in `...` should be numerics, not `", cls, "`s."
-      ))
+      ), call = call)
     }
   }
 }
 
-validate_surv_truth_list_estimate <- function(truth, estimate) {
+validate_surv_truth_list_estimate <- function(truth,
+                                              estimate,
+                                              call = caller_env()) {
   if (!inherits(truth, "Surv")) {
     cls <- class(truth)[[1]]
     abort(paste0(
       "`truth` should be a Surv object, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (!is.list(estimate)) {
     cls <- class(estimate)[[1]]
     abort(paste0(
       "`estimate` should be a list, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (!all(vapply(estimate, is.data.frame, FUN.VALUE = logical(1)))) {
-    abort("All elements of `estimate` should be data.frames.")
+    abort("All elements of `estimate` should be data.frames.", call = call)
   }
 
   valid_names <- c(".eval_time", ".pred_survival",".weight_censored")
@@ -175,7 +182,7 @@ validate_surv_truth_list_estimate <- function(truth, estimate) {
     abort(paste0(
       "All data.frames of `estimate` should include column names: ",
       "`.eval_time`, `.pred_survival`, and `.weight_censored`."
-    ))
+    ), call = call)
   }
 
   n_truth <- nrow(truth)
@@ -185,29 +192,31 @@ validate_surv_truth_list_estimate <- function(truth, estimate) {
     abort(paste0(
       "Length of `truth` (", n_truth, ") ",
       "and `estimate` (", n_estimate, ") must match."
-    ))
+    ), call = call)
   }
 }
 
-validate_surv_truth_numeric_estimate <- function(truth, estimate) {
+validate_surv_truth_numeric_estimate <- function(truth,
+                                                 estimate,
+                                                 call = caller_env()) {
   if (!.is_surv(truth, fail = FALSE)) {
     cls <- class(truth)[[1]]
     abort(paste0(
       "`truth` should be a Surv object, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (!is.numeric(estimate)) {
     cls <- class(estimate)[[1]]
     abort(paste0(
       "`estimate` should be a numeric, not a `", cls, "`."
-    ))
+    ), call = call)
   }
 
   if (is.matrix(estimate)) {
     abort(paste0(
       "`estimate` should be a numeric vector, not a numeric matrix."
-    ))
+    ), call = call)
   }
 
   n_truth <- nrow(truth)
@@ -217,11 +226,11 @@ validate_surv_truth_numeric_estimate <- function(truth, estimate) {
     abort(paste0(
       "Length of `truth` (", n_truth, ") ",
       "and `estimate` (", n_estimate, ") must match."
-    ))
+    ), call = call)
   }
 }
 
-validate_binary_estimator <- function(truth, estimator) {
+validate_binary_estimator <- function(truth, estimator, call = caller_env()) {
   if (estimator != "binary") return()
 
   lvls <- levels(truth)
@@ -229,7 +238,7 @@ validate_binary_estimator <- function(truth, estimator) {
     abort(paste0(
       "`estimator` is binary, only two class `truth` factors are allowed. ",
       "A factor with ", length(lvls), " levels was provided."
-    ))
+    ), call = call)
   }
 }
 
@@ -244,7 +253,9 @@ validate_binary_estimator <- function(truth, estimator) {
 #' this if your classification estimator does not support all of these methods.
 #' @rdname developer-helpers
 #' @export
-validate_estimator <- function(estimator, estimator_override = NULL) {
+validate_estimator <- function(estimator,
+                               estimator_override = NULL,
+                               call = caller_env()) {
 
   if(is.null(estimator)) {
     return()
@@ -260,13 +271,13 @@ validate_estimator <- function(estimator, estimator_override = NULL) {
   if (length(estimator) != 1) {
     abort(paste0(
       "`estimator` must be length 1, not ", length(estimator), "."
-    ))
+    ), call = call)
   }
 
   if (!is.character(estimator)) {
     abort(paste0(
       "`estimator` must be a character, not a ", class(estimator)[1], "."
-    ))
+    ), call = call)
   }
 
   estimator_ok <- (estimator %in% allowed)
@@ -276,12 +287,12 @@ validate_estimator <- function(estimator, estimator_override = NULL) {
     abort(paste0(
       "`estimator` must be one of: ", allowed,
       ". Not ", dQuote(estimator), "."
-    ))
+    ), call = call)
   }
 
 }
 
-validate_case_weights <- function(case_weights, size) {
+validate_case_weights <- function(case_weights, size, call = caller_env()) {
   if (is.null(case_weights)) {
     return(invisible())
   }
@@ -292,7 +303,7 @@ validate_case_weights <- function(case_weights, size) {
     abort(paste0(
       "`case_weights` (", size_case_weights, ") must have the same ",
       "length as `truth` (", size, ")."
-    ))
+    ), call = call)
   }
 
   invisible()

--- a/man/check_metric.Rd
+++ b/man/check_metric.Rd
@@ -34,7 +34,12 @@ check_dynamic_survival_metric(
   call = caller_env()
 )
 
-check_static_survival_metric(truth, estimate, case_weights, call = call())
+check_static_survival_metric(
+  truth,
+  estimate,
+  case_weights,
+  call = caller_env()
+)
 }
 \arguments{
 \item{truth}{The realized vector of \code{truth}.

--- a/man/check_metric.Rd
+++ b/man/check_metric.Rd
@@ -9,15 +9,32 @@
 \alias{check_static_survival_metric}
 \title{Developer function for checking inputs in new metrics}
 \usage{
-check_numeric_metric(truth, estimate, case_weights)
+check_numeric_metric(truth, estimate, case_weights, call = caller_env())
 
-check_class_metric(truth, estimate, case_weights, estimator)
+check_class_metric(
+  truth,
+  estimate,
+  case_weights,
+  estimator,
+  call = caller_env()
+)
 
-check_prob_metric(truth, estimate, case_weights, estimator)
+check_prob_metric(
+  truth,
+  estimate,
+  case_weights,
+  estimator,
+  call = caller_env()
+)
 
-check_dynamic_survival_metric(truth, estimate, case_weights)
+check_dynamic_survival_metric(
+  truth,
+  estimate,
+  case_weights,
+  call = caller_env()
+)
 
-check_static_survival_metric(truth, estimate, case_weights)
+check_static_survival_metric(truth, estimate, case_weights, call = call())
 }
 \arguments{
 \item{truth}{The realized vector of \code{truth}.
@@ -41,6 +58,11 @@ a numeric matrix for multic-class \code{truth}.
 
 \item{case_weights}{The realized case weights, as a numeric vector. This must
 be the same length as \code{truth}.}
+
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
 
 \item{estimator}{This can either be \code{NULL} for the default auto-selection of
 averaging (\code{"binary"} or \code{"macro"}), or a single character to pass along to

--- a/man/developer-helpers.Rd
+++ b/man/developer-helpers.Rd
@@ -14,11 +14,21 @@ dots_to_estimate(data, ...)
 
 get_weights(data, estimator)
 
-finalize_estimator(x, estimator = NULL, metric_class = "default")
+finalize_estimator(
+  x,
+  estimator = NULL,
+  metric_class = "default",
+  call = caller_env()
+)
 
-finalize_estimator_internal(metric_dispatcher, x, estimator)
+finalize_estimator_internal(
+  metric_dispatcher,
+  x,
+  estimator,
+  call = caller_env()
+)
 
-validate_estimator(estimator, estimator_override = NULL)
+validate_estimator(estimator, estimator_override = NULL, call = caller_env())
 }
 \arguments{
 \item{data}{A table with truth values as columns and predicted values

--- a/man/developer-helpers.Rd
+++ b/man/developer-helpers.Rd
@@ -51,6 +51,11 @@ the \code{truth} column, but can also be a table if your metric has table method
 the estimator for. This should match the method name created for
 \code{finalize_estimator_internal()}.}
 
+\item{call}{The execution environment of a currently
+running function, e.g. \code{caller_env()}. The function will be
+mentioned in error messages as the source of the error. See the
+\code{call} argument of \code{\link[rlang:abort]{abort()}} for more information.}
+
 \item{metric_dispatcher}{A simple dummy object with the class provided to
 \code{metric_class}. This is created and passed along for you.}
 

--- a/tests/testthat/_snaps/check_metric.md
+++ b/tests/testthat/_snaps/check_metric.md
@@ -3,7 +3,7 @@
     Code
       check_numeric_metric(1:10, 1:10, 1:11)
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (11) must have the same length as `truth` (10).
 
 # check_numeric_metric() validates inputs
@@ -11,7 +11,7 @@
     Code
       check_numeric_metric(1, "1", 1)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric, not a `character`.
 
 # check_class_metric() validates case_weights
@@ -19,7 +19,7 @@
     Code
       check_class_metric(letters, letters, 1:5)
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (5) must have the same length as `truth` (26).
 
 # check_class_metric() validates inputs
@@ -27,7 +27,7 @@
     Code
       check_class_metric(1, "1", 1)
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `truth` should be a factor, not a `numeric`.
 
 # check_class_metric() validates estimator
@@ -36,7 +36,7 @@
       check_class_metric(factor(c("a", "b", "a"), levels = c("a", "b", "c")), factor(
         c("a", "b", "a"), levels = c("a", "b", "c")), case_weights = 1:3, estimator = "binary")
     Condition
-      Error in `validate_binary_estimator()`:
+      Error:
       ! `estimator` is binary, only two class `truth` factors are allowed. A factor with 3 levels was provided.
 
 # check_prob_metric() validates case_weights
@@ -45,7 +45,7 @@
       check_prob_metric(factor(c("a", "b", "a")), matrix(1:6, nrow = 2), 1:4,
       estimator = "binary")
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (4) must have the same length as `truth` (3).
 
 # check_prob_metric() validates inputs
@@ -54,7 +54,7 @@
       check_prob_metric(factor(c("a", "b", "a")), matrix(1:6, nrow = 2), 1:3,
       estimator = "binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! You are using a binary metric but have passed multiple columns to `...`.
 
 # check_static_survival_metric() validates case_weights
@@ -63,7 +63,7 @@
       check_static_survival_metric(truth = lung_surv$surv_obj, estimate = lung_surv$
         .pred_survival, case_weights = 1:151)
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (151) must have the same length as `truth` (228).
 
 # check_static_survival_metric() validates inputs
@@ -72,6 +72,6 @@
       check_static_survival_metric(truth = lung_surv$surv_obj, estimate = as.character(
         lung_surv$inst), case_weights = 1:150)
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (150) must have the same length as `truth` (228).
 

--- a/tests/testthat/_snaps/class-kap.md
+++ b/tests/testthat/_snaps/class-kap.md
@@ -1,0 +1,16 @@
+# kap errors with wrong `weighting`
+
+    Code
+      kap(three_class, truth = "obs", estimate = "pred", weighting = 1)
+    Condition
+      Error in `kap()`:
+      ! `weighting` must be a string.
+
+---
+
+    Code
+      kap(three_class, truth = "obs", estimate = "pred", weighting = "not right")
+    Condition
+      Error in `kap()`:
+      ! `weighting` must be 'none', 'linear', or 'quadratic'.
+

--- a/tests/testthat/_snaps/conf_mat.md
+++ b/tests/testthat/_snaps/conf_mat.md
@@ -40,7 +40,7 @@
     Code
       conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error in `conf_mat()`:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: virginica, versicolor, setosa
       `estimate`: setosa, versicolor, virginica
@@ -50,7 +50,7 @@
     Code
       conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error in `conf_mat()`:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: 1
       `estimate`: setosa, versicolor, virginica
@@ -60,7 +60,7 @@
     Code
       conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
     Condition
-      Error in `conf_mat_impl()`:
+      Error in `conf_mat()`:
       ! `truth` must have at least 2 factor levels.
 
 # Errors are thrown correctly - grouped
@@ -68,10 +68,7 @@
     Code
       conf_mat(three_class, truth = obs_rev, estimate = pred, dnn = c("", ""))
     Condition
-      Error in `dplyr::summarise()`:
-      i In argument: `conf_mat = { ... }`.
-      i In group 1: `pred = setosa`.
-      Caused by error in `validate_factor_truth_factor_estimate()`:
+      Error in `conf_mat()`:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: virginica, versicolor, setosa
       `estimate`: setosa, versicolor, virginica
@@ -81,10 +78,7 @@
     Code
       conf_mat(three_class, truth = onelevel, estimate = pred, dnn = c("", ""))
     Condition
-      Error in `dplyr::summarise()`:
-      i In argument: `conf_mat = { ... }`.
-      i In group 1: `pred = setosa`.
-      Caused by error in `validate_factor_truth_factor_estimate()`:
+      Error in `conf_mat()`:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: 1
       `estimate`: setosa, versicolor, virginica
@@ -94,10 +88,7 @@
     Code
       conf_mat(three_class, truth = onelevel, estimate = onelevel, dnn = c("", ""))
     Condition
-      Error in `dplyr::summarise()`:
-      i In argument: `conf_mat = { ... }`.
-      i In group 1: `pred = setosa`.
-      Caused by error in `conf_mat_impl()`:
+      Error in `conf_mat()`:
       ! `truth` must have at least 2 factor levels.
 
 # conf_mat()'s errors when wrong things are passes

--- a/tests/testthat/_snaps/error-handling.md
+++ b/tests/testthat/_snaps/error-handling.md
@@ -12,7 +12,7 @@
     Code
       sens(df, truth, estimate)
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error in `sens()`:
       ! `truth` should be a factor, not a `numeric`.
 
 # At least 2 levels in truth
@@ -20,7 +20,7 @@
     Code
       sens(df, truth, estimate)
     Condition
-      Error in `validate_binary_estimator()`:
+      Error in `sens()`:
       ! `estimator` is binary, only two class `truth` factors are allowed. A factor with 1 levels was provided.
 
 # Single character values are caught with correct errors
@@ -46,7 +46,7 @@
     Code
       sens(pathology, pathology, scan, estimator = "blah")
     Condition
-      Error in `validate_estimator()`:
+      Error in `sens()`:
       ! `estimator` must be one of: "binary", "macro", "micro", "macro_weighted". Not "blah".
 
 # Bad estimator + truth combination
@@ -54,7 +54,7 @@
     Code
       sens(hpc_cv, obs, pred, estimator = "binary")
     Condition
-      Error in `validate_binary_estimator()`:
+      Error in `sens()`:
       ! `estimator` is binary, only two class `truth` factors are allowed. A factor with 4 levels was provided.
 
 # Bad estimator type
@@ -62,7 +62,7 @@
     Code
       sens(hpc_cv, obs, pred, estimator = 1)
     Condition
-      Error in `validate_estimator()`:
+      Error in `sens()`:
       ! `estimator` must be a character, not a numeric.
 
 ---
@@ -70,7 +70,7 @@
     Code
       sens(hpc_cv, obs, pred, estimator = c("1", "2"))
     Condition
-      Error in `validate_estimator()`:
+      Error in `sens()`:
       ! `estimator` must be length 1, not 2.
 
 # Numeric matrix in numeric metric
@@ -78,7 +78,7 @@
     Code
       rmse(solubility_test, a, prediction)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error in `rmse()`:
       ! `truth` should be a numeric vector, not a numeric matrix.
 
 ---
@@ -86,7 +86,7 @@
     Code
       rmse(solubility_test, solubility, a)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error in `rmse()`:
       ! `estimate` should be a numeric vector, not a numeric matrix.
 
 # Factors with non identical levels
@@ -94,7 +94,7 @@
     Code
       sens(df, x, y)
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error in `sens()`:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: a, b, c
       `estimate`: a, b
@@ -104,7 +104,7 @@
     Code
       roc_auc(two_class_example, truth, Class1:Class2)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `roc_auc()`:
       ! You are using a binary metric but have passed multiple columns to `...`.
 
 # 1 estimate column for a multiclass metric
@@ -112,7 +112,7 @@
     Code
       roc_auc(hpc_cv, obs, VF)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `roc_auc()`:
       ! The number of levels in `truth` (4) must match the number of columns supplied in `...` (1).
 
 # `truth` and `estimate` of different lengths
@@ -120,7 +120,7 @@
     Code
       rmse_vec(1:5, 1:6)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error in `rmse_vec()`:
       ! Length of `truth` (5) and `estimate` (6) must match.
 
 # Missing arguments

--- a/tests/testthat/_snaps/metrics.md
+++ b/tests/testthat/_snaps/metrics.md
@@ -5,7 +5,7 @@
     Condition
       Error in `metric_set()`:
       ! Failed to compute `accuracy()`.
-      Caused by error in `validate_factor_truth_factor_estimate()`:
+      Caused by error:
       ! `estimate` should be a factor, not a `numeric`.
 
 ---
@@ -15,7 +15,7 @@
     Condition
       Error in `metric_set()`:
       ! Failed to compute `rmse()`.
-      Caused by error in `validate_numeric_truth_numeric_estimate()`:
+      Caused by error:
       ! `estimate` should be a numeric, not a `factor`.
 
 ---
@@ -23,7 +23,7 @@
     Code
       metrics(three_class, "obs", "pred", setosa, versicolor)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `mn_log_loss()`:
       ! The number of levels in `truth` (3) must match the number of columns supplied in `...` (2).
 
 # metrics() - `options` is deprecated

--- a/tests/testthat/_snaps/num-huber_loss.md
+++ b/tests/testthat/_snaps/num-huber_loss.md
@@ -14,3 +14,19 @@
       Error in `huber_loss()`:
       ! `delta` must be a single numeric value.
 
+---
+
+    Code
+      huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = "two")
+    Condition
+      Error in `huber_loss()`:
+      ! `delta` must be a single numeric value.
+
+---
+
+    Code
+      huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = -2)
+    Condition
+      Error in `huber_loss()`:
+      ! `delta` must be a positive value.
+

--- a/tests/testthat/_snaps/num-huber_loss.md
+++ b/tests/testthat/_snaps/num-huber_loss.md
@@ -14,19 +14,3 @@
       Error in `huber_loss()`:
       ! `delta` must be a single numeric value.
 
----
-
-    Code
-      huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = "two")
-    Condition
-      Error in `huber_loss()`:
-      ! `delta` must be a single numeric value.
-
----
-
-    Code
-      huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = -2)
-    Condition
-      Error in `huber_loss()`:
-      ! `delta` must be a positive value.
-

--- a/tests/testthat/_snaps/num-huber_loss.md
+++ b/tests/testthat/_snaps/num-huber_loss.md
@@ -3,7 +3,7 @@
     Code
       huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
     Condition
-      Error in `huber_loss_impl()`:
+      Error in `huber_loss()`:
       ! `delta` must be a positive value.
 
 ---
@@ -11,6 +11,6 @@
     Code
       huber_loss(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1, 2))
     Condition
-      Error in `huber_loss_impl()`:
+      Error in `huber_loss()`:
       ! `delta` must be a single numeric value.
 

--- a/tests/testthat/_snaps/num-mase.md
+++ b/tests/testthat/_snaps/num-mase.md
@@ -3,7 +3,7 @@
     Code
       mase_vec(truth, pred, m = "x")
     Condition
-      Error in `validate_m()`:
+      Error in `mase_vec()`:
       ! `m` must be a single positive integer value.
 
 ---
@@ -11,7 +11,7 @@
     Code
       mase_vec(truth, pred, m = -1)
     Condition
-      Error in `validate_m()`:
+      Error in `mase_vec()`:
       ! `m` must be a single positive integer value.
 
 ---
@@ -19,7 +19,7 @@
     Code
       mase_vec(truth, pred, m = 1.5)
     Condition
-      Error in `validate_m()`:
+      Error in `mase_vec()`:
       ! `m` must be a single positive integer value.
 
 ---
@@ -27,7 +27,7 @@
     Code
       mase_vec(truth, pred, mae_train = -1)
     Condition
-      Error in `validate_mae_train()`:
+      Error in `mase_vec()`:
       ! `mae_train` must be a single positive numeric value.
 
 ---
@@ -35,6 +35,6 @@
     Code
       mase_vec(truth, pred, mae_train = "x")
     Condition
-      Error in `validate_mae_train()`:
+      Error in `mase_vec()`:
       ! `mae_train` must be a single positive numeric value.
 

--- a/tests/testthat/_snaps/num-pseudo_huber_loss.md
+++ b/tests/testthat/_snaps/num-pseudo_huber_loss.md
@@ -3,7 +3,7 @@
     Code
       huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = -1)
     Condition
-      Error in `huber_loss_pseudo_impl()`:
+      Error in `huber_loss_pseudo()`:
       ! `delta` must be a positive value.
 
 ---
@@ -11,6 +11,6 @@
     Code
       huber_loss_pseudo(ex_dat, truth = "obs", estimate = "pred_na", delta = c(1, 2))
     Condition
-      Error in `huber_loss_pseudo_impl()`:
+      Error in `huber_loss_pseudo()`:
       ! `delta` must be a single numeric value.
 

--- a/tests/testthat/_snaps/prob-classification_cost.md
+++ b/tests/testthat/_snaps/prob-classification_cost.md
@@ -3,7 +3,7 @@
     Code
       classification_cost(two_class_example, truth, Class1:Class2)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `classification_cost()`:
       ! You are using a binary metric but have passed multiple columns to `...`.
 
 # costs must be a data frame with the right column names
@@ -11,7 +11,7 @@
     Code
       classification_cost(df, obs, A, costs = 1)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs` must be `NULL` or a data.frame.
 
 ---
@@ -19,7 +19,7 @@
     Code
       classification_cost(df, obs, A, costs = data.frame())
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs` must be a data.frame with 3 columns.
 
 ---
@@ -27,7 +27,7 @@
     Code
       classification_cost(df, obs, A, costs = data.frame(x = 1, y = 2, z = 3))
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs` must have columns: 'truth', 'estimate', and 'cost'.
 
 # costs$estimate must contain the right levels
@@ -35,7 +35,7 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs$estimate` can only contain 'A', 'B'.
 
 # costs$truth must contain the right levels
@@ -43,7 +43,7 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs$truth` can only contain 'A', 'B'.
 
 # costs$truth, costs$estimate, and costs$cost must have the right type
@@ -51,7 +51,7 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs$truth` must be a character or factor column.
 
 ---
@@ -59,7 +59,7 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs$estimate` must be a character or factor column.
 
 ---
@@ -67,7 +67,7 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs$cost` must be a numeric column.
 
 # costs$truth and costs$estimate cannot contain duplicate pairs
@@ -75,6 +75,6 @@
     Code
       classification_cost(df, obs, A, costs = costs)
     Condition
-      Error in `validate_costs()`:
+      Error in `classification_cost()`:
       ! `costs` cannot have duplicate 'truth' / 'estimate' combinations.
 

--- a/tests/testthat/_snaps/prob-gain_curve.md
+++ b/tests/testthat/_snaps/prob-gain_curve.md
@@ -3,6 +3,6 @@
     Code
       gain_curve(df, truth, estimate)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `gain_curve()`:
       ! `truth` should be a factor, not a `numeric`.
 

--- a/tests/testthat/_snaps/prob-lift_curve.md
+++ b/tests/testthat/_snaps/prob-lift_curve.md
@@ -3,6 +3,6 @@
     Code
       lift_curve(df, truth, estimate)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `lift_curve()`:
       ! `truth` should be a factor, not a `numeric`.
 

--- a/tests/testthat/_snaps/prob-roc_auc.md
+++ b/tests/testthat/_snaps/prob-roc_auc.md
@@ -81,7 +81,7 @@
     Code
       roc_auc(hpc_cv, obs, VF:L, estimator = "hand_till", case_weights = weight)
     Condition
-      Error in `finalize_estimator_roc_auc()`:
+      Error in `roc_auc()`:
       ! Can't specify both `estimator = 'hand_till'` and `case_weights`.
 
 # roc_auc() - `options` is deprecated

--- a/tests/testthat/_snaps/prob-roc_aunp.md
+++ b/tests/testthat/_snaps/prob-roc_aunp.md
@@ -3,7 +3,7 @@
     Code
       roc_aunp(two_class_example, truth, Class1)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `roc_aunp()`:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
 
 # roc_aunp() - `options` is deprecated

--- a/tests/testthat/_snaps/prob-roc_aunu.md
+++ b/tests/testthat/_snaps/prob-roc_aunu.md
@@ -3,7 +3,7 @@
     Code
       roc_aunu(two_class_example, truth, Class1)
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error in `roc_aunu()`:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
 
 # roc_aunu() - `options` is deprecated

--- a/tests/testthat/_snaps/template.md
+++ b/tests/testthat/_snaps/template.md
@@ -24,7 +24,7 @@
       numeric_metric_summarizer(name = "rmse", fn = rmse_vec, data = mtcars, truth = mpg,
         estimate = disp, obviouslywrong = TRUE)
     Condition
-      Error in `numeric_metric_summarizer()`:
+      Error:
       ! `...` must be empty.
       x Problematic argument:
       * obviouslywrong = TRUE
@@ -55,7 +55,7 @@
       class_metric_summarizer(name = "accuracy", fn = accuracy_vec, data = three_class,
         truth = obs, estimate = pred, obviouslywrong = TRUE)
     Condition
-      Error in `class_metric_summarizer()`:
+      Error:
       ! `...` must be empty.
       x Problematic argument:
       * obviouslywrong = TRUE
@@ -172,7 +172,7 @@
       static_survival_metric_summarizer(name = "concordance_survival", fn = concordance_survival_vec,
         data = lung_surv, truth = surv_obj, estimate = .pred_time, obviouslywrong = TRUE)
     Condition
-      Error in `static_survival_metric_summarizer()`:
+      Error:
       ! `...` must be empty.
       x Problematic argument:
       * obviouslywrong = TRUE

--- a/tests/testthat/_snaps/template.md
+++ b/tests/testthat/_snaps/template.md
@@ -126,7 +126,7 @@
       dynamic_survival_metric_summarizer(name = "brier_survival", fn = brier_survival_vec,
         data = lung_surv, truth = .pred_time, .pred)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `truth` should be a Surv object, not a `numeric`.
 
 ---
@@ -135,7 +135,7 @@
       dynamic_survival_metric_summarizer(name = "brier_survival", fn = brier_survival_vec,
         data = lung_surv, truth = surv_obj, surv_obj)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `estimate` should be a list, not a `Surv`.
 
 # static_survival_metric_summarizer()'s errors with bad input
@@ -154,7 +154,7 @@
       static_survival_metric_summarizer(name = "concordance_survival", fn = concordance_survival_vec,
         data = lung_surv, truth = surv_obj, estimate = surv_obj)
     Condition
-      Error in `validate_surv_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric vector, not a numeric matrix.
 
 ---
@@ -163,7 +163,7 @@
       static_survival_metric_summarizer(name = "concordance_survival", fn = concordance_survival_vec,
         data = lung_surv, truth = surv_obj, estimate = list)
     Condition
-      Error in `validate_surv_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric, not a `list`.
 
 ---
@@ -183,7 +183,7 @@
       curve_survival_metric_summarizer(name = "roc_curve_survival", fn = roc_curve_survival_vec,
         data = lung_surv, truth = .pred_time, .pred)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `truth` should be a Surv object, not a `numeric`.
 
 ---
@@ -192,6 +192,6 @@
       curve_survival_metric_summarizer(name = "roc_curve_survival", fn = roc_curve_survival_vec,
         data = lung_surv, truth = surv_obj, surv_obj)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `estimate` should be a list, not a `Surv`.
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -3,7 +3,7 @@
     Code
       validate_numeric_truth_numeric_estimate("1", 1)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! `truth` should be a numeric, not a `character`.
 
 ---
@@ -11,7 +11,7 @@
     Code
       validate_numeric_truth_numeric_estimate(1, "1")
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric, not a `character`.
 
 ---
@@ -19,7 +19,7 @@
     Code
       validate_numeric_truth_numeric_estimate(matrix(1), 1)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! `truth` should be a numeric vector, not a numeric matrix.
 
 ---
@@ -27,7 +27,7 @@
     Code
       validate_numeric_truth_numeric_estimate(1, matrix(1))
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric vector, not a numeric matrix.
 
 ---
@@ -35,7 +35,7 @@
     Code
       validate_numeric_truth_numeric_estimate(1:4, 1:5)
     Condition
-      Error in `validate_numeric_truth_numeric_estimate()`:
+      Error:
       ! Length of `truth` (4) and `estimate` (5) must match.
 
 ---
@@ -44,7 +44,7 @@
       validate_binary_estimator(factor(c("a", "b", "a"), levels = c("a", "b", "c")),
       estimator = "binary")
     Condition
-      Error in `validate_binary_estimator()`:
+      Error:
       ! `estimator` is binary, only two class `truth` factors are allowed. A factor with 3 levels was provided.
 
 # validate_factor_truth_factor_estimate errors as expected
@@ -52,7 +52,7 @@
     Code
       validate_factor_truth_factor_estimate("1", 1)
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `truth` should be a factor, not a `character`.
 
 ---
@@ -61,7 +61,7 @@
       validate_factor_truth_factor_estimate(c("a", "b", "a"), factor(c("a", "a", "a"),
       levels = c("a", "b")))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `truth` should be a factor, not a `character`.
 
 ---
@@ -70,7 +70,7 @@
       validate_factor_truth_factor_estimate(factor(c("a", "a", "a"), levels = c("a",
         "b")), c("a", "b", "a"))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `estimate` should be a factor, not a `character`.
 
 ---
@@ -79,7 +79,7 @@
       validate_factor_truth_factor_estimate(factor(c("a", "a", "a"), levels = c("a",
         "b")), 1:3)
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `estimate` should be a factor, not a `integer`.
 
 ---
@@ -88,7 +88,7 @@
       validate_factor_truth_factor_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), factor(c("a", "a", "a"), levels = c("a", "b", "c")))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! `truth` and `estimate` levels must be equivalent.
       `truth`: a, b
       `estimate`: a, b, c
@@ -99,7 +99,7 @@
       validate_factor_truth_factor_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), factor(c("a", "a", "a", "a"), levels = c("a", "b")))
     Condition
-      Error in `validate_factor_truth_factor_estimate()`:
+      Error:
       ! Length of `truth` (3) and `estimate` (4) must match.
 
 # validate_factor_truth_matrix_estimate errors as expected for binary
@@ -107,7 +107,7 @@
     Code
       validate_factor_truth_matrix_estimate(c("a", "b", "a"), 1:3, estimator = "binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! `truth` should be a factor, not a `character`.
 
 ---
@@ -116,7 +116,7 @@
       validate_factor_truth_matrix_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), c("a", "b", "a"), estimator = "binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! `estimate` should be a numeric vector, not a `character` vector.
 
 ---
@@ -125,7 +125,7 @@
       validate_factor_truth_matrix_estimate(factor(character(), levels = c("a", "b")),
       matrix(1:6, ncol = 2), estimator = "binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! You are using a binary metric but have passed multiple columns to `...`.
 
 ---
@@ -134,7 +134,7 @@
       validate_factor_truth_matrix_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b", "c")), 1:3, estimator = "binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! `estimator` is binary, only two class `truth` factors are allowed. A factor with 3 levels was provided.
 
 # validate_factor_truth_matrix_estimate errors as expected for non-binary
@@ -143,7 +143,7 @@
       validate_factor_truth_matrix_estimate(c("a", "b", "a"), matrix(1:6, ncol = 2),
       estimator = "non binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! `truth` should be a factor, not a `character`.
 
 ---
@@ -152,7 +152,7 @@
       validate_factor_truth_matrix_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), 1:3, estimator = "non binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
 
 ---
@@ -161,7 +161,7 @@
       validate_factor_truth_matrix_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), matrix(as.character(1:6), ncol = 2), estimator = "non binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! The columns supplied in `...` should be numerics, not `character`s.
 
 ---
@@ -170,7 +170,7 @@
       validate_factor_truth_matrix_estimate(factor(c("a", "b", "a"), levels = c("a",
         "b")), matrix(1:15, ncol = 5), estimator = "non binary")
     Condition
-      Error in `validate_factor_truth_matrix_estimate()`:
+      Error:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (5).
 
 # validate_surv_truth_numeric_estimate errors as expected
@@ -178,7 +178,7 @@
     Code
       validate_surv_truth_numeric_estimate("1", 1)
     Condition
-      Error in `validate_surv_truth_numeric_estimate()`:
+      Error:
       ! `truth` should be a Surv object, not a `character`.
 
 ---
@@ -187,7 +187,7 @@
       validate_surv_truth_numeric_estimate(lung_surv$surv_obj, as.character(lung_surv$
         .pred_time))
     Condition
-      Error in `validate_surv_truth_numeric_estimate()`:
+      Error:
       ! `estimate` should be a numeric, not a `character`.
 
 ---
@@ -196,7 +196,7 @@
       validate_surv_truth_numeric_estimate(lung_surv$surv_obj[1:5, ], lung_surv$
         .pred_time)
     Condition
-      Error in `validate_surv_truth_numeric_estimate()`:
+      Error:
       ! Length of `truth` (5) and `estimate` (228) must match.
 
 # validate_surv_truth_list_estimate errors as expected
@@ -204,7 +204,7 @@
     Code
       validate_surv_truth_list_estimate("1", 1)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `truth` should be a Surv object, not a `character`.
 
 ---
@@ -212,7 +212,7 @@
     Code
       validate_surv_truth_list_estimate(lung_surv$surv_obj, lung_surv$list)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! All elements of `estimate` should be data.frames.
 
 ---
@@ -220,7 +220,7 @@
     Code
       validate_surv_truth_list_estimate(lung_surv$surv_obj, lung_surv$list2)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! All data.frames of `estimate` should include column names: `.eval_time`, `.pred_survival`, and `.weight_censored`.
 
 ---
@@ -228,7 +228,7 @@
     Code
       validate_surv_truth_list_estimate(lung_surv$surv_obj, lung_surv$list4)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! All data.frames of `estimate` should include column names: `.eval_time`, `.pred_survival`, and `.weight_censored`.
 
 ---
@@ -237,7 +237,7 @@
       validate_surv_truth_list_estimate(lung_surv$surv_obj, as.character(lung_surv$
         .pred_time))
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `estimate` should be a list, not a `character`.
 
 ---
@@ -246,7 +246,7 @@
       validate_surv_truth_list_estimate(lung_surv$surv_obj[1:5, ], lung_surv$
         .pred_time)
     Condition
-      Error in `validate_surv_truth_list_estimate()`:
+      Error:
       ! `estimate` should be a list, not a `numeric`.
 
 # validate_case_weights errors as expected
@@ -254,6 +254,6 @@
     Code
       validate_case_weights(1:10, 11)
     Condition
-      Error in `validate_case_weights()`:
+      Error:
       ! `case_weights` (10) must have the same length as `truth` (11).
 

--- a/tests/testthat/test-class-kap.R
+++ b/tests/testthat/test-class-kap.R
@@ -12,6 +12,21 @@ test_that("two class produces identical results regardless of level order", {
   )
 })
 
+test_that("kap errors with wrong `weighting`", {
+  lst <- data_three_class()
+  three_class <- lst$three_class
+
+  expect_snapshot(
+    error = TRUE,
+    kap(three_class, truth = "obs", estimate = "pred", weighting = 1)
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    kap(three_class, truth = "obs", estimate = "pred", weighting = "not right")
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 # expected results from e1071::classAgreement(three_class_tb)$kappa

--- a/tests/testthat/test-num-huber_loss.R
+++ b/tests/testthat/test-num-huber_loss.R
@@ -39,21 +39,6 @@ test_that('Huber Loss', {
   )
 })
 
-test_that('Huber Loss', {
-  ex_dat <- generate_numeric_test_data()
-  not_na <- !is.na(ex_dat$pred_na)
-
-  expect_snapshot(
-    error = TRUE,
-    huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = "two")
-  )
-
-  expect_snapshot(
-    error = TRUE,
-    huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = -2)
-  )
-})
-
 test_that("Weighted results are working", {
   truth <- c(1, 2, 3)
   estimate <- c(2, 4, 3)

--- a/tests/testthat/test-num-huber_loss.R
+++ b/tests/testthat/test-num-huber_loss.R
@@ -39,6 +39,21 @@ test_that('Huber Loss', {
   )
 })
 
+test_that('Huber Loss', {
+  ex_dat <- generate_numeric_test_data()
+  not_na <- !is.na(ex_dat$pred_na)
+
+  expect_snapshot(
+    error = TRUE,
+    huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = "two")
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    huber_loss(ex_dat, truth = "obs", estimate = "pred", delta = -2)
+  )
+})
+
 test_that("Weighted results are working", {
   truth <- c(1, 2, 3)
   estimate <- c(2, 4, 3)


### PR DESCRIPTION
This PR should finally close https://github.com/tidymodels/yardstick/issues/348.

Purpose of this PR is to pass `call`s around so we are properly omitting the calling functions instead of the underlying  functions

This PR is mostly concerned with passing around `call`s, making the errors better will be done in https://github.com/tidymodels/yardstick/issues/418 and https://github.com/tidymodels/yardstick/issues/419

# This PR

``` r
library(yardstick)

accuracy_vec(mtcars$vs, mtcars$am)
#> Error in `accuracy_vec()`:
#> ! `truth` should be a factor, not a `numeric`.

accuracy(mtcars, vs, am)
#> Error in `accuracy()`:
#> ! `truth` should be a factor, not a `numeric`.
```

# CRAN

``` r
library(yardstick)


accuracy_vec(mtcars$vs, mtcars$am)
#> Error in `validate_class()`:
#> ! `truth` should be a factor but a numeric was supplied.

accuracy(mtcars, vs, am)
#> Error in `dplyr::summarise()`:
#> ℹ In argument: `.estimate = metric_fn(truth = vs, estimate = am, na_rm =
#>   na_rm)`.
#> Caused by error in `validate_class()`:
#> ! `truth` should be a factor but a numeric was supplied.
```