### PR TITLE
Don't namespace functions from rlang or vctrs

### DIFF
--- a/R/aaa-new.R
+++ b/R/aaa-new.R
@@ -66,10 +66,10 @@ new_static_survival_metric <- function(fn, direction) {
 
 new_metric <- function(fn, direction, class = NULL) {
   if (!is.function(fn)) {
-    rlang::abort("`fn` must be a function.")
+    abort("`fn` must be a function.")
   }
 
-  direction <- rlang::arg_match(
+  direction <- arg_match(
     direction,
     values = c("maximize", "minimize", "zero")
   )

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -164,7 +164,7 @@ make_weighting_matrix <- function(weighting, n_levels) {
   }
 
   # [n_levels x n_levels], 0 on diagonal, increasing weighting on off-diagonal
-  w <- rlang::seq2(0L, n_levels - 1L)
+  w <- seq2(0L, n_levels - 1L)
   w <- matrix(w, nrow = n_levels, ncol = n_levels)
   w <- abs(w - t(w)) ^ power
 
@@ -174,7 +174,7 @@ make_weighting_matrix <- function(weighting, n_levels) {
 # ------------------------------------------------------------------------------
 
 validate_weighting <- function(x) {
-  if (!rlang::is_string(x)) {
+  if (!is_string(x)) {
     abort("`weighting` must be a string.")
   }
 

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -214,7 +214,7 @@ warn_precision_undefined_multiclass <- function(events, counts) {
 }
 
 warn_precision_undefined <- function(message, events, counts, ..., class = character()) {
-  rlang::warn(
+  warn(
     message = message,
     class = c(class, "yardstick_warning_precision_undefined"),
     events = events,

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -216,7 +216,7 @@ warn_recall_undefined_multiclass <- function(events, counts) {
 }
 
 warn_recall_undefined <- function(message, events, counts, ..., class = character()) {
-  rlang::warn(
+  warn(
     message = message,
     class = c(class, "yardstick_warning_recall_undefined"),
     events = events,

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -313,7 +313,7 @@ warn_sens_undefined_multiclass <- function(events, counts) {
 }
 
 warn_sens_undefined <- function(message, events, counts, ..., class = character()) {
-  rlang::warn(
+  warn(
     message = message,
     class = c(class, "yardstick_warning_sens_undefined"),
     events = events,

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -287,7 +287,7 @@ warn_spec_undefined_multiclass <- function(events, counts) {
 }
 
 warn_spec_undefined <- function(message, events, counts, ..., class = character()) {
-  rlang::warn(
+  warn(
     message = message,
     class = c(class, "yardstick_warning_spec_undefined"),
     events = events,

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -364,7 +364,7 @@ summary.conf_mat <- function(object,
 
 # Dynamically exported
 autoplot.conf_mat <- function(object, type = "mosaic", ...) {
-  type <- rlang::arg_match(type, conf_mat_plot_types)
+  type <- arg_match(type, conf_mat_plot_types)
 
   switch(type,
     mosaic = cm_mosaic(object),

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -185,7 +185,7 @@ conf_mat.grouped_df <- function(data,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -211,7 +211,7 @@ conf_mat.grouped_df <- function(data,
     out[[i]] <- conf_mat.matrix(table)
   }
 
-  out <- vctrs::vec_cbind(group_keys, conf_mat = out)
+  out <- vec_cbind(group_keys, conf_mat = out)
   out
 }
 

--- a/R/deprecated-prob_helpers.R
+++ b/R/deprecated-prob_helpers.R
@@ -40,7 +40,7 @@ dots_to_estimate <- function(data, ...) {
   )
 
   # Capture dots
-  dot_vars <- rlang::with_handlers(
+  dot_vars <- with_handlers(
     tidyselect::vars_select(names(data), !!! enquos(...)),
     tidyselect_empty_dots = function(cnd) {
       abort("No valid variables provided to `...`.")

--- a/R/deprecated-template.R
+++ b/R/deprecated-template.R
@@ -88,7 +88,7 @@ metric_summarizer <- function(metric_nm,
   truth <- handle_chr_names(truth, nms)
   estimate <- handle_chr_names(estimate, nms)
 
-  finalize_estimator_expr <- rlang::expr(
+  finalize_estimator_expr <- expr(
     finalize_estimator(!! truth, estimator, metric_nm)
   )
 
@@ -114,7 +114,7 @@ metric_summarizer <- function(metric_nm,
 # Utilities
 
 validate_not_missing <- function(x, nm) {
-  if(rlang::quo_is_missing(x)) {
+  if(quo_is_missing(x)) {
     abort(paste0(
       "`", nm, "` ",
       "is missing and must be supplied."
@@ -141,7 +141,7 @@ handle_chr_names <- function(x, nms) {
 }
 
 spliceable_case_weights <- function(case_weights) {
-  if (rlang::quo_is_null(case_weights)) {
+  if (quo_is_null(case_weights)) {
     return(list())
   }
 

--- a/R/estimator-helpers.R
+++ b/R/estimator-helpers.R
@@ -29,7 +29,7 @@ get_weights <- function(data, estimator) {
   else {
 
     msg <- paste0("`estimator` type `", estimator, "` is unknown.")
-    rlang::abort(msg)
+    abort(msg)
 
   }
 }

--- a/R/event-level.R
+++ b/R/event-level.R
@@ -33,5 +33,5 @@ validate_event_level <- function(event_level) {
     return(invisible())
   }
 
-  rlang::abort("`event_level` must be 'first' or 'second'.")
+  abort("`event_level` must be 'first' or 'second'.")
 }

--- a/R/import-standalone-survival.R
+++ b/R/import-standalone-survival.R
@@ -68,7 +68,7 @@
 .is_surv <- function(surv, fail = TRUE) {
   is_surv <- inherits(surv, "Surv")
   if (!is_surv && fail) {
-    rlang::abort("The object does not have class `Surv`.", call = NULL)
+    abort("The object does not have class `Surv`.", call = NULL)
   }
   is_surv
 }
@@ -84,7 +84,7 @@
   if (!good_type && fail) {
     c_list <- paste0("'", type, "'")
     msg <- cli::format_inline("For this usage, the allowed censoring type{?s} {?is/are}: {c_list}")
-    rlang::abort(msg, call = NULL)
+    abort(msg, call = NULL)
   }
   good_type
 }

--- a/R/metric-tweak.R
+++ b/R/metric-tweak.R
@@ -51,25 +51,25 @@
 #' metrics <- metric_set(mase, mase10, mase12)
 #' metrics(solubility_test, solubility, prediction)
 metric_tweak <- function(.name, .fn, ...) {
-  if (!rlang::is_string(.name)) {
-    rlang::abort("`.name` must be a string.")
+  if (!is_string(.name)) {
+    abort("`.name` must be a string.")
   }
   if (!is_metric(.fn)) {
-    rlang::abort("`.fn` must be a metric function.")
+    abort("`.fn` must be a metric function.")
   }
 
-  fixed <- rlang::enquos(...)
+  fixed <- enquos(...)
 
-  if (length(fixed) > 0 && !rlang::is_named(fixed)) {
-    rlang::abort("All arguments passed through `...` must be named.")
+  if (length(fixed) > 0 && !is_named(fixed)) {
+    abort("All arguments passed through `...` must be named.")
   }
 
   check_protected_names(fixed)
 
   out <- function(...) {
-    args <- rlang::enquos(...)
-    call <- rlang::call2(.fn, !!!args, !!!fixed)
-    out <- rlang::eval_tidy(call)
+    args <- enquos(...)
+    call <- call2(.fn, !!!args, !!!fixed)
+    out <- eval_tidy(call)
     out[[".metric"]] <- .name
     out
   }
@@ -92,7 +92,7 @@ check_protected_names <- function(fixed) {
 
   protected <- quote_and_collapse(protected)
 
-  rlang::abort(paste0(
+  abort(paste0(
     "Arguments passed through `...` cannot be named any of: ",
     protected,
     "."

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -312,10 +312,10 @@ get_metric_fn_direction <- function(x) {
 }
 
 get_quo_label <- function(quo) {
-  out <- rlang::as_label(quo)
+  out <- as_label(quo)
 
   if (length(out) != 1L) {
-    rlang::abort("Internal error: `as_label(quo)` resulted in a character vector of length >1.")
+    abort("Internal error: `as_label(quo)` resulted in a character vector of length >1.")
   }
 
   is_namespaced <- grepl("::", out, fixed = TRUE)
@@ -353,7 +353,7 @@ make_prob_class_metric_function <- function(fns) {
     metric_list <- list()
 
     # Evaluate class metrics
-    if(!rlang::is_empty(class_fns)) {
+    if(!is_empty(class_fns)) {
 
       class_args <- quos(
         data = data,
@@ -379,7 +379,7 @@ make_prob_class_metric_function <- function(fns) {
     }
 
     # Evaluate prob metrics
-    if(!rlang::is_empty(prob_fns)) {
+    if(!is_empty(prob_fns)) {
 
       # TODO - If prob metrics can all do micro, we can remove this
       if (!is.null(estimator) && estimator == "micro") {
@@ -535,7 +535,7 @@ make_survival_metric_function <- function(fns) {
 }
 
 validate_not_empty <- function(x) {
-  if (rlang::is_empty(x)) {
+  if (is_empty(x)) {
     abort("`metric_set()` requires at least 1 function supplied to `...`.")
   }
 }
@@ -629,7 +629,7 @@ validate_function_class <- function(fns) {
 
     env_names_other <- vapply(
       fns_other,
-      function(fn) rlang::env_name(rlang::fn_env(fn)),
+      function(fn) env_name(fn_env(fn)),
       character(1)
     )
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -4,7 +4,7 @@
 
 pos_val <- function(xtab, event_level) {
   if (!all(dim(xtab) == 2)) {
-    rlang::abort("Only relevant for 2x2 tables")
+    abort("Only relevant for 2x2 tables")
   }
 
   if (is_event_first(event_level)) {
@@ -16,7 +16,7 @@ pos_val <- function(xtab, event_level) {
 
 neg_val <- function(xtab, event_level) {
   if (!all(dim(xtab) == 2)) {
-    rlang::abort("Only relevant for 2x2 tables")
+    abort("Only relevant for 2x2 tables")
   }
 
   if (is_event_first(event_level)) {
@@ -60,8 +60,8 @@ is_class_pred <- function(x) {
 }
 
 as_factor_from_class_pred <- function(x) {
-  if (!rlang::is_installed("probably")) {
-    rlang::abort(paste0(
+  if (!is_installed("probably")) {
+    abort(paste0(
       "A <class_pred> input was detected, but the probably package ",
       "isn't installed. Install probably to be able to convert <class_pred> ",
       "to <factor>."
@@ -295,7 +295,7 @@ make_correlation_undefined_constant_message <- function(what) {
 }
 
 warn_correlation_undefined <- function(message, ..., class = character()) {
-  rlang::warn(
+  warn(
     message = message,
     class = c(class, "yardstick_warning_correlation_undefined"),
     ...

--- a/R/num-huber_loss.R
+++ b/R/num-huber_loss.R
@@ -84,7 +84,7 @@ huber_loss_impl <- function(truth,
   # Weighted Huber Loss implementation confirmed against matlab:
   # https://www.mathworks.com/help/deeplearning/ref/dlarray.huber.html
 
-  if (!rlang::is_bare_numeric(delta, n = 1L)) {
+  if (!is_bare_numeric(delta, n = 1L)) {
     abort("`delta` must be a single numeric value.")
   }
   if (!(delta >= 0)) {

--- a/R/num-mase.R
+++ b/R/num-mase.R
@@ -141,7 +141,7 @@ mase_impl <- function(truth,
 validate_m <- function(m) {
   abort_msg <- "`m` must be a single positive integer value."
 
-  if (!rlang::is_integerish(m, n = 1L)) {
+  if (!is_integerish(m, n = 1L)) {
     abort(abort_msg)
   }
 
@@ -157,7 +157,7 @@ validate_mae_train <- function(mae_train) {
     return(invisible(mae_train))
   }
 
-  is_single_numeric <- rlang::is_bare_numeric(mae_train, n = 1L)
+  is_single_numeric <- is_bare_numeric(mae_train, n = 1L)
   abort_msg <- "`mae_train` must be a single positive numeric value."
 
   if (!is_single_numeric) {

--- a/R/num-pseudo_huber_loss.R
+++ b/R/num-pseudo_huber_loss.R
@@ -85,7 +85,7 @@ huber_loss_pseudo_impl <- function(truth,
                                    estimate,
                                    delta,
                                    case_weights) {
-  if (!rlang::is_bare_numeric(delta, n = 1L)) {
+  if (!is_bare_numeric(delta, n = 1L)) {
     abort("`delta` must be a single numeric value.")
   }
   if (!(delta >= 0)) {

--- a/R/prob-brier.R
+++ b/R/prob-brier.R
@@ -149,7 +149,7 @@ brier_ind <- function(truth, estimate, case_weights = NULL) {
 # When `truth` is a factor
 brier_factor <- function(truth, estimate, case_weights = NULL) {
   if (!is.factor(truth)) {
-    rlang::abort("'truth' should be a factor.")
+    abort("'truth' should be a factor.")
   }
 
   inds <- hardhat::fct_encode_one_hot(truth)

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -252,13 +252,13 @@ validate_costs <- function(costs, levels) {
    }
 
    ok <- all(costs$truth %in% levels)
-   if (rlang::is_false(ok)) {
+   if (is_false(ok)) {
       levels <- quote_and_collapse(levels)
       abort(paste0("`costs$truth` can only contain ", levels, "."))
    }
 
    ok <- all(costs$estimate %in% levels)
-   if (rlang::is_false(ok)) {
+   if (is_false(ok)) {
       levels <- quote_and_collapse(levels)
       abort(paste0("`costs$estimate` can only contain ", levels, "."))
    }

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -266,7 +266,7 @@ validate_costs <- function(costs, levels) {
    pairs <- costs[c("truth", "estimate")]
    cost <- costs$cost
 
-   not_ok <- vctrs::vec_duplicate_any(pairs)
+   not_ok <- vec_duplicate_any(pairs)
    if (not_ok) {
       abort("`costs` cannot have duplicate 'truth' / 'estimate' combinations.")
    }
@@ -274,7 +274,7 @@ validate_costs <- function(costs, levels) {
    out <- generate_all_level_combinations(levels)
 
    # Detect user specified cost locations
-   locs <- vctrs::vec_match(pairs, out)
+   locs <- vec_match(pairs, out)
 
    # Default to no cost
    out$cost <- 0
@@ -333,9 +333,9 @@ recycle_costs <- function(costs, truth) {
    # Expand `costs` to equal size of `truth`, matching the `truth` values
    needles <- truth
    haystack <- factor(costs$truth, levels = levels)
-   locs <- vctrs::vec_match(needles, haystack)
+   locs <- vec_match(needles, haystack)
 
-   costs <- vctrs::vec_slice(costs, locs)
+   costs <- vec_slice(costs, locs)
 
    costs
 }

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -264,7 +264,7 @@ autoplot.gain_df <- function(object, ...) {
     # Construct the color interaction group
     grps <- dplyr::groups(object)
     interact_expr <- list(
-      color = rlang::expr(interaction(!!! grps, sep = "_"))
+      color = expr(interaction(!!! grps, sep = "_"))
     )
 
     # Add group legend label

--- a/R/prob-helpers.R
+++ b/R/prob-helpers.R
@@ -38,7 +38,7 @@ one_vs_all_impl <- function(fn,
   lvls <- levels(truth)
   other <- "..other"
 
-  metric_lst <- rlang::new_list(n = length(lvls))
+  metric_lst <- new_list(n = length(lvls))
 
   # one vs all
   for(i in seq_along(lvls)) {

--- a/R/prob-lift_curve.R
+++ b/R/prob-lift_curve.R
@@ -156,7 +156,7 @@ autoplot.lift_df <- function(object, ...) {
     # Construct the color interaction group
     grps <- dplyr::groups(object)
     interact_expr <- list(
-      color = rlang::expr(interaction(!!! grps, sep = "_"))
+      color = expr(interaction(!!! grps, sep = "_"))
     )
 
     # Add group legend label

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -205,7 +205,7 @@ autoplot.pr_df <- function(object, ...) {
     grps_chr <- paste0(dplyr::group_vars(object), collapse = "_")
 
     interact_expr <- list(
-      color = rlang::expr(interaction(!!! grps, sep = "_"))
+      color = expr(interaction(!!! grps, sep = "_"))
     )
 
     pr_chart <- pr_chart %+%

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -315,7 +315,7 @@ roc_auc_hand_till <- function(truth, estimate) {
       "Computation will proceed by ignoring those levels."
     )
 
-    rlang::warn(msg)
+    warn(msg)
 
     # Proceed with non-missing levels
     lvls <- lvls[!indicator_missing]
@@ -388,13 +388,13 @@ msg_roc_truth_no_control <- function(control) {
   )
 }
 warn_roc_truth_no_control <- function(control) {
-  rlang::warn(
+  warn(
     msg_roc_truth_no_control(control),
     class = "yardstick_warning_roc_truth_no_control"
   )
 }
 stop_roc_truth_no_control <- function(control) {
-  rlang::abort(
+  abort(
     msg_roc_truth_no_control(control),
     class = "yardstick_error_roc_truth_no_control"
   )
@@ -407,13 +407,13 @@ msg_roc_truth_no_event <- function(event) {
   )
 }
 warn_roc_truth_no_event <- function(event) {
-  rlang::warn(
+  warn(
     msg_roc_truth_no_event(event),
     class = "yardstick_warning_roc_truth_no_event"
   )
 }
 stop_roc_truth_no_event <- function(event) {
-  rlang::abort(
+  abort(
     msg_roc_truth_no_event(event),
     class = "yardstick_error_roc_truth_no_event"
   )

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -234,7 +234,7 @@ autoplot.roc_df <- function(object, ...) {
     grps_chr <- paste0(dplyr::group_vars(object), collapse = "_")
 
     interact_expr <- list(
-      color = rlang::expr(interaction(!!! grps, sep = "_"))
+      color = expr(interaction(!!! grps, sep = "_"))
     )
 
     roc_chart <- roc_chart %+%

--- a/R/surv-roc_curve_survival.R
+++ b/R/surv-roc_curve_survival.R
@@ -174,7 +174,7 @@ roc_curve_survival_impl_one <- function(event_time, delta, data) {
     ge_time = obs_time_gt_time,
     multiplier = multiplier
   )
-  data_split <- vctrs::vec_split(data_df, data$.pred_survival)
+  data_split <- vec_split(data_df, data$.pred_survival)
   data_split <- data_split$val[order(data_split$key)]
 
   sensitivity <- vapply(

--- a/R/template.R
+++ b/R/template.R
@@ -114,7 +114,7 @@ numeric_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -147,9 +147,9 @@ numeric_metric_summarizer <- function(name,
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }
@@ -201,7 +201,7 @@ class_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -237,9 +237,9 @@ class_metric_summarizer <- function(name,
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }
@@ -286,7 +286,7 @@ prob_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -322,9 +322,9 @@ prob_metric_summarizer <- function(name,
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }
@@ -371,7 +371,7 @@ curve_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -404,13 +404,13 @@ curve_metric_summarizer <- function(name,
       )
     )
 
-    elt_out <- vctrs::vec_recycle_common(!!!elt_out)
+    elt_out <- vec_recycle_common(!!!elt_out)
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }
@@ -455,7 +455,7 @@ dynamic_survival_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -485,13 +485,13 @@ dynamic_survival_metric_summarizer <- function(name,
       )
     )
 
-    elt_out <- vctrs::vec_recycle_common(!!!elt_out)
+    elt_out <- vec_recycle_common(!!!elt_out)
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   if (inherits(out$.estimate, "tbl_df")) {
     out <- tidyr::unnest(out, .estimate)
@@ -545,7 +545,7 @@ static_survival_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -578,9 +578,9 @@ static_survival_metric_summarizer <- function(name,
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }
@@ -625,7 +625,7 @@ curve_survival_metric_summarizer <- function(name,
   group_rows <- dplyr::group_rows(data)
   group_keys <- dplyr::group_keys(data)
   data <- dplyr::ungroup(data)
-  groups <- vctrs::vec_chop(data, indices = group_rows)
+  groups <- vec_chop(data, indices = group_rows)
   out <- vector("list", length = length(groups))
 
   for (i in seq_along(groups)) {
@@ -655,13 +655,13 @@ curve_survival_metric_summarizer <- function(name,
       )
     )
 
-    elt_out <- vctrs::vec_recycle_common(!!!elt_out)
+    elt_out <- vec_recycle_common(!!!elt_out)
     out[[i]] <- tibble::new_tibble(elt_out)
   }
 
-  group_keys <- vctrs::vec_rep_each(group_keys, times = list_sizes(out))
-  out <- vctrs::vec_rbind(!!!out)
-  out <- vctrs::vec_cbind(group_keys, out)
+  group_keys <- vec_rep_each(group_keys, times = list_sizes(out))
+  out <- vec_rbind(!!!out)
+  out <- vec_cbind(group_keys, out)
 
   out
 }

--- a/R/template.R
+++ b/R/template.R
@@ -81,7 +81,7 @@ numeric_metric_summarizer <- function(name,
                                       case_weights = NULL,
                                       fn_options = list(),
                                       error_call = caller_env()) {
-  rlang::check_dots_empty()
+  check_dots_empty()
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -133,7 +133,7 @@ numeric_metric_summarizer <- function(name,
         group_truth,
         metric_class = name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -168,7 +168,7 @@ class_metric_summarizer <- function(name,
                                     case_weights = NULL,
                                     fn_options = list(),
                                     error_call = caller_env()) {
-  rlang::check_dots_empty()
+  check_dots_empty()
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -221,7 +221,7 @@ class_metric_summarizer <- function(name,
         estimator,
         name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -306,7 +306,7 @@ prob_metric_summarizer <- function(name,
         estimator,
         name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -391,7 +391,7 @@ curve_metric_summarizer <- function(name,
         estimator,
         name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -474,7 +474,7 @@ dynamic_survival_metric_summarizer <- function(name,
         group_truth,
         metric_class = name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -512,7 +512,7 @@ static_survival_metric_summarizer <- function(name,
                                               case_weights = NULL,
                                               fn_options = list(),
                                               error_call = caller_env()) {
-  rlang::check_dots_empty()
+  check_dots_empty()
 
   truth <- enquo(truth)
   estimate <- enquo(estimate)
@@ -564,7 +564,7 @@ static_survival_metric_summarizer <- function(name,
         group_truth,
         metric_class = name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,
@@ -644,7 +644,7 @@ curve_survival_metric_summarizer <- function(name,
         group_truth,
         metric_class = name
       ),
-      .estimate = rlang::inject(
+      .estimate = inject(
         fn(
           truth = group_truth,
           estimate = group_estimate,


### PR DESCRIPTION
Both {rlang} and {vctrs} are imported. So I'm going to make this change to remove some visual clutter in the codebase