### PR TITLE
fully support class_pred input in metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@
 
 * Error messages now show what user-facing function was called (#348). 
 
+* classification and probability metrics now fully support `class_pred` objects from {probably} package (#341).
+
 # yardstick 1.1.0
 
 * Emil Hvitfeldt is now the maintainer (#315).

--- a/R/class-accuracy.R
+++ b/R/class-accuracy.R
@@ -82,6 +82,13 @@ accuracy.matrix <- function(data, ...) {
 #' @export
 #' @rdname accuracy
 accuracy_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "accuracy")
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-accuracy.R
+++ b/R/class-accuracy.R
@@ -83,10 +83,7 @@ accuracy.matrix <- function(data, ...) {
 #' @rdname accuracy
 accuracy_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, metric_class = "accuracy")
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-accuracy.R
+++ b/R/class-accuracy.R
@@ -82,15 +82,13 @@ accuracy.matrix <- function(data, ...) {
 #' @export
 #' @rdname accuracy
 accuracy_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }
 
   estimator <- finalize_estimator(truth, metric_class = "accuracy")
-
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -82,10 +82,7 @@ bal_accuracy_vec <- function(truth,
                              event_level = yardstick_event_level(),
                              ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -81,6 +81,13 @@ bal_accuracy_vec <- function(truth,
                              case_weights = NULL,
                              event_level = yardstick_event_level(),
                              ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -81,9 +81,8 @@ bal_accuracy_vec <- function(truth,
                              case_weights = NULL,
                              event_level = yardstick_event_level(),
                              ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-detection_prevalence.R
+++ b/R/class-detection_prevalence.R
@@ -80,9 +80,8 @@ detection_prevalence_vec <- function(truth,
                                      case_weights = NULL,
                                      event_level = yardstick_event_level(),
                                      ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-detection_prevalence.R
+++ b/R/class-detection_prevalence.R
@@ -80,6 +80,13 @@ detection_prevalence_vec <- function(truth,
                                      case_weights = NULL,
                                      event_level = yardstick_event_level(),
                                      ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-detection_prevalence.R
+++ b/R/class-detection_prevalence.R
@@ -81,10 +81,7 @@ detection_prevalence_vec <- function(truth,
                                      event_level = yardstick_event_level(),
                                      ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -107,6 +107,13 @@ f_meas_vec <- function(truth,
                        case_weights = NULL,
                        event_level = yardstick_event_level(),
                        ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -108,10 +108,7 @@ f_meas_vec <- function(truth,
                        event_level = yardstick_event_level(),
                        ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -107,9 +107,8 @@ f_meas_vec <- function(truth,
                        case_weights = NULL,
                        event_level = yardstick_event_level(),
                        ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -101,6 +101,13 @@ j_index_vec <- function(truth,
                         case_weights = NULL,
                         event_level = yardstick_event_level(),
                         ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -101,9 +101,8 @@ j_index_vec <- function(truth,
                         case_weights = NULL,
                         event_level = yardstick_event_level(),
                         ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -102,10 +102,7 @@ j_index_vec <- function(truth,
                         event_level = yardstick_event_level(),
                         ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -113,9 +113,8 @@ kap_vec <- function(truth,
                     na_rm = TRUE,
                     case_weights = NULL,
                     ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -113,6 +113,13 @@ kap_vec <- function(truth,
                     na_rm = TRUE,
                     case_weights = NULL,
                     ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "kap")
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -114,10 +114,7 @@ kap_vec <- function(truth,
                     case_weights = NULL,
                     ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, metric_class = "kap")
 

--- a/R/class-mcc.R
+++ b/R/class-mcc.R
@@ -98,10 +98,7 @@ mcc_vec <- function(truth,
                     case_weights = NULL,
                     ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, metric_class = "mcc")
 

--- a/R/class-mcc.R
+++ b/R/class-mcc.R
@@ -97,9 +97,8 @@ mcc_vec <- function(truth,
                     na_rm = TRUE,
                     case_weights = NULL,
                     ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-mcc.R
+++ b/R/class-mcc.R
@@ -97,6 +97,13 @@ mcc_vec <- function(truth,
                     na_rm = TRUE,
                     case_weights = NULL,
                     ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "mcc")
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -99,9 +99,8 @@ npv_vec <- function(truth,
                     case_weights = NULL,
                     event_level = yardstick_event_level(),
                     ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -99,6 +99,13 @@ npv_vec <- function(truth,
                     case_weights = NULL,
                     event_level = yardstick_event_level(),
                     ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -100,10 +100,7 @@ npv_vec <- function(truth,
                     event_level = yardstick_event_level(),
                     ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -117,10 +117,7 @@ ppv_vec <- function(truth,
                     event_level = yardstick_event_level(),
                     ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -116,9 +116,8 @@ ppv_vec <- function(truth,
                     case_weights = NULL,
                     event_level = yardstick_event_level(),
                     ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -116,6 +116,13 @@ ppv_vec <- function(truth,
                     case_weights = NULL,
                     event_level = yardstick_event_level(),
                     ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -107,10 +107,7 @@ precision_vec <- function(truth,
                           event_level = yardstick_event_level(),
                           ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -106,6 +106,13 @@ precision_vec <- function(truth,
                           case_weights = NULL,
                           event_level = yardstick_event_level(),
                           ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -106,9 +106,8 @@ precision_vec <- function(truth,
                           case_weights = NULL,
                           event_level = yardstick_event_level(),
                           ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -107,6 +107,13 @@ recall_vec <- function(truth,
                        case_weights = NULL,
                        event_level = yardstick_event_level(),
                        ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -107,9 +107,8 @@ recall_vec <- function(truth,
                        case_weights = NULL,
                        event_level = yardstick_event_level(),
                        ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -108,10 +108,7 @@ recall_vec <- function(truth,
                        event_level = yardstick_event_level(),
                        ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -136,9 +136,8 @@ sens_vec <- function(truth,
                      case_weights = NULL,
                      event_level = yardstick_event_level(),
                      ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -136,6 +136,13 @@ sens_vec <- function(truth,
                      case_weights = NULL,
                      event_level = yardstick_event_level(),
                      ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -137,10 +137,7 @@ sens_vec <- function(truth,
                      event_level = yardstick_event_level(),
                      ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -102,9 +102,8 @@ spec_vec <- function(truth,
                      case_weights = NULL,
                      event_level = yardstick_event_level(),
                      ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -103,10 +103,7 @@ spec_vec <- function(truth,
                      event_level = yardstick_event_level(),
                      ...) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, estimator)
 

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -102,6 +102,13 @@ spec_vec <- function(truth,
                      case_weights = NULL,
                      event_level = yardstick_event_level(),
                      ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- finalize_estimator(truth, estimator)
 
   check_class_metric(truth, estimate, case_weights, estimator)

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -217,10 +217,7 @@ conf_mat.grouped_df <- function(data,
 
 conf_mat_impl <- function(truth, estimate, case_weights, call = caller_env()) {
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- "not binary"
   check_class_metric(truth, estimate, case_weights, estimator, call = call)

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -216,6 +216,13 @@ conf_mat.grouped_df <- function(data,
 }
 
 conf_mat_impl <- function(truth, estimate, case_weights, call = caller_env()) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+  if (is_class_pred(estimate)) {
+    estimate <- as_factor_from_class_pred(estimate)
+  }
+
   estimator <- "not binary"
   check_class_metric(truth, estimate, case_weights, estimator, call = call)
 

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -216,9 +216,8 @@ conf_mat.grouped_df <- function(data,
 }
 
 conf_mat_impl <- function(truth, estimate, case_weights, call = caller_env()) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/deprecated-template.R
+++ b/R/deprecated-template.R
@@ -215,9 +215,8 @@ metric_vec_template <- function(metric_impl,
       )
     )
   )
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }

--- a/R/deprecated-template.R
+++ b/R/deprecated-template.R
@@ -216,10 +216,7 @@ metric_vec_template <- function(metric_impl,
     )
   )
   abort_if_class_pred(truth)
-
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
+  estimate <- as_factor_from_class_pred(estimate)
 
   validate_truth_estimate_checks(truth, estimate, cls, estimator)
   validate_case_weights(case_weights, size = length(truth))

--- a/R/metrics.R
+++ b/R/metrics.R
@@ -82,13 +82,6 @@ metrics.data.frame <- function(data,
   estimate <- tidyselect::vars_pull(names, {{estimate}})
   probs <- unname(tidyselect::vars_select(names, ...))
 
-  if (is_class_pred(data[[truth]])) {
-    data[[truth]] <- as_factor_from_class_pred(data[[truth]])
-  }
-  if (is_class_pred(data[[estimate]])) {
-    data[[estimate]] <- as_factor_from_class_pred(data[[estimate]])
-  }
-
   is_class <- is.factor(data[[truth]]) || is_class_pred(data[[truth]])
 
   if (is_class) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -70,6 +70,15 @@ as_factor_from_class_pred <- function(x) {
   probably::as.factor(x)
 }
 
+abort_if_class_pred <- function(x, call = caller_env()) {
+  if (is_class_pred(x)) {
+    abort(
+      "`truth` should not a `class_pred` object.",
+      call = call
+    )
+  }
+  return(invisible(x))
+}
 # ------------------------------------------------------------------------------
 
 curve_finalize <- function(result, data, class, grouped_class) {
@@ -375,9 +384,8 @@ weighted_quantile <- function(x, weights, probabilities) {
 yardstick_table <- function(truth, estimate, ..., case_weights = NULL) {
   check_dots_empty()
 
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
+
   if (is_class_pred(estimate)) {
     estimate <- as_factor_from_class_pred(estimate)
   }
@@ -430,9 +438,7 @@ yardstick_truth_table <- function(truth, ..., case_weights = NULL) {
 
   check_dots_empty()
 
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   if (!is.factor(truth)) {
     abort("`truth` must be a factor.", .internal = TRUE)

--- a/R/misc.R
+++ b/R/misc.R
@@ -60,6 +60,10 @@ is_class_pred <- function(x) {
 }
 
 as_factor_from_class_pred <- function(x) {
+  if (!is_class_pred(x)) {
+    return(x)
+  }
+
   if (!is_installed("probably")) {
     abort(paste0(
       "A <class_pred> input was detected, but the probably package ",

--- a/R/missings.R
+++ b/R/missings.R
@@ -57,13 +57,6 @@ yardstick_remove_missing <- function(truth,
 yardstick_any_missing <- function(truth,
                                   estimate,
                                   case_weights) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
-
   anyNA(truth) ||
     anyNA(estimate) ||
     (!is.null(case_weights) && anyNA(case_weights))

--- a/R/prob-average_precision.R
+++ b/R/prob-average_precision.R
@@ -88,9 +88,7 @@ average_precision_vec <- function(truth,
                                   event_level = yardstick_event_level(),
                                   case_weights = NULL,
                                   ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "average_precision")
 

--- a/R/prob-average_precision.R
+++ b/R/prob-average_precision.R
@@ -88,6 +88,10 @@ average_precision_vec <- function(truth,
                                   event_level = yardstick_event_level(),
                                   case_weights = NULL,
                                   ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, estimator, "average_precision")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-brier.R
+++ b/R/prob-brier.R
@@ -83,9 +83,7 @@ brier_class_vec <- function(truth,
                             na_rm = TRUE,
                             case_weights = NULL,
                             ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "brier_class")
 

--- a/R/prob-brier.R
+++ b/R/prob-brier.R
@@ -83,6 +83,10 @@ brier_class_vec <- function(truth,
                             na_rm = TRUE,
                             case_weights = NULL,
                             ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "brier_class")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -140,6 +140,10 @@ classification_cost_vec <- function(truth,
                                     event_level = yardstick_event_level(),
                                     case_weights = NULL,
                                     ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
    estimator <- finalize_estimator(truth, metric_class = "classification_cost")
 
    check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -140,9 +140,7 @@ classification_cost_vec <- function(truth,
                                     event_level = yardstick_event_level(),
                                     case_weights = NULL,
                                     ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
    estimator <- finalize_estimator(truth, metric_class = "classification_cost")
 

--- a/R/prob-gain_capture.R
+++ b/R/prob-gain_capture.R
@@ -85,6 +85,10 @@ gain_capture_vec <- function(truth,
                              event_level = yardstick_event_level(),
                              case_weights = NULL,
                              ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, estimator, "gain_capture")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-gain_capture.R
+++ b/R/prob-gain_capture.R
@@ -85,9 +85,7 @@ gain_capture_vec <- function(truth,
                              event_level = yardstick_event_level(),
                              case_weights = NULL,
                              ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "gain_capture")
 

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -135,9 +135,7 @@ gain_curve_vec <- function(truth,
                            event_level = yardstick_event_level(),
                            case_weights = NULL,
                            ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "gain_curve")
 

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -135,6 +135,10 @@ gain_curve_vec <- function(truth,
                            event_level = yardstick_event_level(),
                            case_weights = NULL,
                            ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "gain_curve")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-lift_curve.R
+++ b/R/prob-lift_curve.R
@@ -129,6 +129,10 @@ lift_curve_vec <- function(truth,
     case_weights = case_weights
   )
 
+  if (identical(res, NA_real_)) {
+    return(res)
+  }
+
   res <- dplyr::mutate(res, .lift = .percent_found / .percent_tested)
 
   res[[".percent_found"]] <- NULL

--- a/R/prob-mn_log_loss.R
+++ b/R/prob-mn_log_loss.R
@@ -109,9 +109,7 @@ mn_log_loss_vec <- function(truth,
                             event_level = yardstick_event_level(),
                             case_weights = NULL,
                             ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "mn_log_loss")
 

--- a/R/prob-mn_log_loss.R
+++ b/R/prob-mn_log_loss.R
@@ -109,6 +109,10 @@ mn_log_loss_vec <- function(truth,
                             event_level = yardstick_event_level(),
                             case_weights = NULL,
                             ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "mn_log_loss")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-pr_auc.R
+++ b/R/prob-pr_auc.R
@@ -82,9 +82,7 @@ pr_auc_vec <- function(truth,
                        event_level = yardstick_event_level(),
                        case_weights = NULL,
                        ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "pr_auc")
 

--- a/R/prob-pr_auc.R
+++ b/R/prob-pr_auc.R
@@ -82,6 +82,10 @@ pr_auc_vec <- function(truth,
                        event_level = yardstick_event_level(),
                        case_weights = NULL,
                        ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, estimator, "pr_auc")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -91,9 +91,7 @@ pr_curve_vec <- function(truth,
                          event_level = yardstick_event_level(),
                          case_weights = NULL,
                          ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "pr_curve")
 

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -91,6 +91,10 @@ pr_curve_vec <- function(truth,
                          event_level = yardstick_event_level(),
                          case_weights = NULL,
                          ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "pr_curve")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -122,6 +122,10 @@ roc_auc_vec <- function(truth,
                         case_weights = NULL,
                         options = list(),
                         ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   check_roc_options_deprecated("roc_auc_vec", options)
 
   estimator <- finalize_estimator_roc_auc(

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -122,9 +122,7 @@ roc_auc_vec <- function(truth,
                         case_weights = NULL,
                         options = list(),
                         ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_auc_vec", options)
 

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -117,6 +117,10 @@ roc_aunp_vec <- function(truth,
                          case_weights = NULL,
                          options = list(),
                          ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   check_roc_options_deprecated("roc_aunp_vec", options)
 
   estimator <- "macro_weighted"

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -117,9 +117,7 @@ roc_aunp_vec <- function(truth,
                          case_weights = NULL,
                          options = list(),
                          ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_aunp_vec", options)
 

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -117,6 +117,10 @@ roc_aunu_vec <- function(truth,
                          case_weights = NULL,
                          options = list(),
                          ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   check_roc_options_deprecated("roc_aunu_vec", options)
 
   estimator <- "macro"

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -117,9 +117,7 @@ roc_aunu_vec <- function(truth,
                          case_weights = NULL,
                          options = list(),
                          ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_aunu_vec", options)
 

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -98,9 +98,7 @@ roc_curve_vec <- function(truth,
                           event_level = yardstick_event_level(),
                           case_weights = NULL,
                           ...) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
+  abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "roc_curve")
 

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -98,6 +98,10 @@ roc_curve_vec <- function(truth,
                           event_level = yardstick_event_level(),
                           case_weights = NULL,
                           ...) {
+  if (is_class_pred(truth)) {
+    truth <- as_factor_from_class_pred(truth)
+  }
+
   estimator <- finalize_estimator(truth, metric_class = "roc_curve")
 
   check_prob_metric(truth, estimate, case_weights, estimator)

--- a/R/validation.R
+++ b/R/validation.R
@@ -41,12 +41,6 @@ validate_numeric_truth_numeric_estimate <- function(truth,
 validate_factor_truth_factor_estimate <- function(truth,
                                                   estimate,
                                                   call = caller_env()) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
-  if (is_class_pred(estimate)) {
-    estimate <- as_factor_from_class_pred(estimate)
-  }
   if (!is.factor(truth)) {
     cls <- class(truth)[[1]]
     abort(paste0(
@@ -93,10 +87,6 @@ validate_factor_truth_matrix_estimate <- function(truth,
                                                   estimate,
                                                   estimator,
                                                   call = caller_env()) {
-  if (is_class_pred(truth)) {
-    truth <- as_factor_from_class_pred(truth)
-  }
-
   if (!is.factor(truth)) {
     cls <- class(truth)[[1]]
     abort(paste0(

--- a/tests/testthat/_snaps/class-accuracy.md
+++ b/tests/testthat/_snaps/class-accuracy.md
@@ -1,0 +1,8 @@
+# work with class_pred input
+
+    Code
+      accuracy_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `accuracy_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-bal_accuracy.md
+++ b/tests/testthat/_snaps/class-bal_accuracy.md
@@ -1,0 +1,8 @@
+# work with class_pred input
+
+    Code
+      bal_accuracy(cp_truth, cp_estimate)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'bal_accuracy' applied to an object of class "c('class_pred', 'vctrs_vctr')"
+

--- a/tests/testthat/_snaps/class-detection_prevalence.md
+++ b/tests/testthat/_snaps/class-detection_prevalence.md
@@ -1,0 +1,8 @@
+# work with class_pred input
+
+    Code
+      detection_prevalence_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `detection_prevalence_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-f_meas.md
+++ b/tests/testthat/_snaps/class-f_meas.md
@@ -74,3 +74,11 @@
       Note that the following number of true events actually occured for each problematic event level:
       'c': 1
 
+# work with class_pred input
+
+    Code
+      f_meas_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `f_meas_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-j_index.md
+++ b/tests/testthat/_snaps/class-j_index.md
@@ -46,3 +46,11 @@
       Note that the following number of predicted negatives actually occured for each problematic event level:
       'a': 2
 
+# work with class_pred input
+
+    Code
+      j_index_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `j_index_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-kap.md
+++ b/tests/testthat/_snaps/class-kap.md
@@ -14,3 +14,11 @@
       Error in `kap()`:
       ! `weighting` must be 'none', 'linear', or 'quadratic'.
 
+# work with class_pred input
+
+    Code
+      kap_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `kap_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-mcc.md
+++ b/tests/testthat/_snaps/class-mcc.md
@@ -1,0 +1,8 @@
+# work with class_pred input
+
+    Code
+      mcc_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `mcc_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-npv.md
+++ b/tests/testthat/_snaps/class-npv.md
@@ -1,0 +1,8 @@
+# work with class_pred input
+
+    Code
+      accuracy_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `accuracy_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-ppv.md
+++ b/tests/testthat/_snaps/class-ppv.md
@@ -8,3 +8,11 @@
       Sensitivity is undefined in this case, and `NA` will be returned.
       Note that 1 predicted event(s) actually occured for the problematic event level, 'a'.
 
+# work with class_pred input
+
+    Code
+      ppv_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `ppv_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-precision.md
+++ b/tests/testthat/_snaps/class-precision.md
@@ -32,3 +32,11 @@
       Note that the following number of true events actually occured for each problematic event level:
       'c': 1
 
+# work with class_pred input
+
+    Code
+      precision_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `precision_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-recall.md
+++ b/tests/testthat/_snaps/class-recall.md
@@ -20,3 +20,11 @@
       'b': 0
       'c': 1
 
+# work with class_pred input
+
+    Code
+      recall_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `recall_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-sens.md
+++ b/tests/testthat/_snaps/class-sens.md
@@ -20,3 +20,11 @@
       'b': 0
       'c': 1
 
+# work with class_pred input
+
+    Code
+      sensitivity_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `sensitivity_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/class-spec.md
+++ b/tests/testthat/_snaps/class-spec.md
@@ -19,3 +19,11 @@
       Note that the following number of predicted negatives actually occured for each problematic event level:
       'a': 2
 
+# work with class_pred input
+
+    Code
+      specificity_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `specificity_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-average_precision.md
+++ b/tests/testthat/_snaps/prob-average_precision.md
@@ -22,3 +22,11 @@
       Warning:
       There are `0` event cases in `truth`, results will be meaningless.
 
+# errors with class_pred input
+
+    Code
+      average_precision_vec(cp_truth, estimate)
+    Condition
+      Error in `average_precision_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-brier-class.md
+++ b/tests/testthat/_snaps/prob-brier-class.md
@@ -1,0 +1,8 @@
+# errors with class_pred input
+
+    Code
+      brier_class_vec(cp_truth, estimate)
+    Condition
+      Error in `brier_class_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-classification_cost.md
+++ b/tests/testthat/_snaps/prob-classification_cost.md
@@ -78,3 +78,11 @@
       Error in `classification_cost()`:
       ! `costs` cannot have duplicate 'truth' / 'estimate' combinations.
 
+# errors with class_pred input
+
+    Code
+      classification_cost_vec(cp_truth, estimate)
+    Condition
+      Error in `classification_cost_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-gain_capture.md
+++ b/tests/testthat/_snaps/prob-gain_capture.md
@@ -1,0 +1,8 @@
+# errors with class_pred input
+
+    Code
+      gain_capture_vec(cp_truth, estimate)
+    Condition
+      Error in `gain_capture_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-gain_curve.md
+++ b/tests/testthat/_snaps/prob-gain_curve.md
@@ -6,3 +6,11 @@
       Error in `gain_curve()`:
       ! `truth` should be a factor, not a `numeric`.
 
+# errors with class_pred input
+
+    Code
+      gain_curve_vec_vec(cp_truth, estimate)
+    Condition
+      Error in `gain_curve_vec_vec()`:
+      ! could not find function "gain_curve_vec_vec"
+

--- a/tests/testthat/_snaps/prob-lift_curve.md
+++ b/tests/testthat/_snaps/prob-lift_curve.md
@@ -6,3 +6,11 @@
       Error in `lift_curve()`:
       ! `truth` should be a factor, not a `numeric`.
 
+# errors with class_pred input
+
+    Code
+      lift_curve_vec(cp_truth, estimate)
+    Condition
+      Error in `gain_curve_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-mn_log_loss.md
+++ b/tests/testthat/_snaps/prob-mn_log_loss.md
@@ -1,0 +1,8 @@
+# errors with class_pred input
+
+    Code
+      mn_log_loss_vec(cp_truth, estimate)
+    Condition
+      Error in `mn_log_loss_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-pr_auc.md
+++ b/tests/testthat/_snaps/prob-pr_auc.md
@@ -1,0 +1,8 @@
+# errors with class_pred input
+
+    Code
+      pr_auc_vec(cp_truth, estimate)
+    Condition
+      Error in `pr_auc_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-pr_curve.md
+++ b/tests/testthat/_snaps/prob-pr_curve.md
@@ -6,3 +6,11 @@
       Warning:
       There are `0` event cases in `truth`, results will be meaningless.
 
+# errors with class_pred input
+
+    Code
+      pr_curve_vec(cp_truth, estimate)
+    Condition
+      Error in `pr_curve_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-roc_auc.md
+++ b/tests/testthat/_snaps/prob-roc_auc.md
@@ -103,3 +103,11 @@
       The `options` argument of `roc_auc_vec()` was deprecated in yardstick 1.0.0.
       i This argument no longer has any effect, and is being ignored. Use the pROC package directly if you need these features.
 
+# errors with class_pred input
+
+    Code
+      roc_auc_vec(cp_truth, estimate)
+    Condition
+      Error in `roc_auc_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-roc_aunp.md
+++ b/tests/testthat/_snaps/prob-roc_aunp.md
@@ -25,3 +25,11 @@
       The `options` argument of `roc_aunp_vec()` was deprecated in yardstick 1.0.0.
       i This argument no longer has any effect, and is being ignored. Use the pROC package directly if you need these features.
 
+# work with class_pred input
+
+    Code
+      roc_aunp_vec(cp_truth, estimate)
+    Condition
+      Error in `roc_aunp_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-roc_aunu.md
+++ b/tests/testthat/_snaps/prob-roc_aunu.md
@@ -25,3 +25,11 @@
       The `options` argument of `roc_aunu_vec()` was deprecated in yardstick 1.0.0.
       i This argument no longer has any effect, and is being ignored. Use the pROC package directly if you need these features.
 
+# errors with class_pred input
+
+    Code
+      roc_aunu_vec(cp_truth, estimate)
+    Condition
+      Error in `roc_aunu_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/prob-roc_curve.md
+++ b/tests/testthat/_snaps/prob-roc_curve.md
@@ -32,3 +32,11 @@
       The `options` argument of `roc_curve()` was deprecated in yardstick 1.0.0.
       i This argument no longer has any effect, and is being ignored. Use the pROC package directly if you need these features.
 
+# errors with class_pred input
+
+    Code
+      roc_curve_vec(cp_truth, estimate)
+    Condition
+      Error in `roc_curve_vec()`:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/_snaps/probably.md
+++ b/tests/testthat/_snaps/probably.md
@@ -1,0 +1,34 @@
+# `class_pred` can be converted to `factor` when computing metrics
+
+    Code
+      accuracy_vec(cp_truth, cp_estimate)
+    Condition
+      Error in `accuracy_vec()`:
+      ! `truth` should not a `class_pred` object.
+
+# `class_pred` errors when passed to `conf_mat()`
+
+    Code
+      conf_mat(cp_hpc_cv, obs, pred)
+    Condition
+      Error in `conf_mat_impl()`:
+      ! `truth` should not a `class_pred` object.
+
+---
+
+    Code
+      conf_mat(dplyr::group_by(cp_hpc_cv, Resample), obs, pred)
+    Condition
+      Error in `conf_mat_impl()`:
+      ! `truth` should not a `class_pred` object.
+
+# `class_pred` errors when passed to `metrics()`
+
+    Code
+      metrics(cp_df, truth, estimate, class1)
+    Condition
+      Error in `metric_set()`:
+      ! Failed to compute `accuracy()`.
+      Caused by error:
+      ! `truth` should not a `class_pred` object.
+

--- a/tests/testthat/test-class-accuracy.R
+++ b/tests/testthat/test-class-accuracy.R
@@ -71,13 +71,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    accuracy_vec(cp_truth, cp_estimate),
+    accuracy_vec(fct_truth, cp_estimate),
     accuracy_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    accuracy_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    accuracy_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    accuracy_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-accuracy.R
+++ b/tests/testthat/test-class-accuracy.R
@@ -58,6 +58,29 @@ test_that("two class with case weights is correct", {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    accuracy_vec(cp_truth, cp_estimate),
+    accuracy_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    accuracy_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 test_that('Two class - sklearn equivalent', {
   py_res <- read_pydata("py-accuracy")
   r_metric <- accuracy

--- a/tests/testthat/test-class-bal_accuracy.R
+++ b/tests/testthat/test-class-bal_accuracy.R
@@ -61,13 +61,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    bal_accuracy_vec(cp_truth, cp_estimate),
+    bal_accuracy_vec(fct_truth, cp_estimate),
     bal_accuracy_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    bal_accuracy_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    bal_accuracy_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    bal_accuracy(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-bal_accuracy.R
+++ b/tests/testthat/test-class-bal_accuracy.R
@@ -48,6 +48,29 @@ test_that('Three class', {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    bal_accuracy_vec(cp_truth, cp_estimate),
+    bal_accuracy_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    bal_accuracy_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 test_that('Two class weighted - sklearn equivalent', {

--- a/tests/testthat/test-class-detection_prevalence.R
+++ b/tests/testthat/test-class-detection_prevalence.R
@@ -62,3 +62,26 @@ test_that("two class with case weights is correct", {
     3/4
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    detection_prevalence_vec(cp_truth, cp_estimate),
+    detection_prevalence_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    detection_prevalence_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-class-detection_prevalence.R
+++ b/tests/testthat/test-class-detection_prevalence.R
@@ -76,12 +76,17 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    detection_prevalence_vec(cp_truth, cp_estimate),
+    detection_prevalence_vec(fct_truth, cp_estimate),
     detection_prevalence_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    detection_prevalence_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    detection_prevalence_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    detection_prevalence_vec(cp_truth, cp_estimate)
   )
 })

--- a/tests/testthat/test-class-f_meas.R
+++ b/tests/testthat/test-class-f_meas.R
@@ -121,6 +121,29 @@ test_that("`NA` is still returned if there are some undefined recall values but 
   expect_warning(f_meas_vec(truth, estimate, na_rm = FALSE), NA)
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    f_meas_vec(cp_truth, cp_estimate),
+    f_meas_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    f_meas_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # sklearn compare --------------------------------------------------------------
 
 test_that('Two class - sklearn equivalent', {

--- a/tests/testthat/test-class-f_meas.R
+++ b/tests/testthat/test-class-f_meas.R
@@ -134,13 +134,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    f_meas_vec(cp_truth, cp_estimate),
+    f_meas_vec(fct_truth, cp_estimate),
     f_meas_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    f_meas_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    f_meas_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    f_meas_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-j_index.R
+++ b/tests/testthat/test-class-j_index.R
@@ -141,12 +141,17 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    j_index_vec(cp_truth, cp_estimate),
+    j_index_vec(fct_truth, cp_estimate),
     j_index_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    j_index_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    j_index_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    j_index_vec(cp_truth, cp_estimate)
   )
 })

--- a/tests/testthat/test-class-j_index.R
+++ b/tests/testthat/test-class-j_index.R
@@ -127,3 +127,26 @@ test_that("`NA` is still returned if there are some undefined sensitivity values
   expect_equal(j_index_vec(truth, estimate, na_rm = FALSE), NA_real_)
   expect_warning(j_index_vec(truth, estimate, na_rm = FALSE), NA)
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    j_index_vec(cp_truth, cp_estimate),
+    j_index_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    j_index_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-class-kap.R
+++ b/tests/testthat/test-class-kap.R
@@ -27,6 +27,29 @@ test_that("kap errors with wrong `weighting`", {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    kap_vec(cp_truth, cp_estimate),
+    kap_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    kap_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 # expected results from e1071::classAgreement(three_class_tb)$kappa

--- a/tests/testthat/test-class-kap.R
+++ b/tests/testthat/test-class-kap.R
@@ -40,13 +40,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    kap_vec(cp_truth, cp_estimate),
+    kap_vec(fct_truth, cp_estimate),
     kap_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    kap_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    kap_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    kap_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-mcc.R
+++ b/tests/testthat/test-class-mcc.R
@@ -39,6 +39,30 @@ test_that("doesn't integer overflow (#108)", {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    mcc_vec(cp_truth, cp_estimate),
+    mcc_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    mcc_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
+
 # sklearn compare --------------------------------------------------------------
 
 test_that('Two class - sklearn equivalent', {

--- a/tests/testthat/test-class-mcc.R
+++ b/tests/testthat/test-class-mcc.R
@@ -52,13 +52,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    mcc_vec(cp_truth, cp_estimate),
+    mcc_vec(fct_truth, cp_estimate),
     mcc_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    mcc_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    mcc_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    mcc_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-npv.R
+++ b/tests/testthat/test-class-npv.R
@@ -71,6 +71,29 @@ test_that('Three class', {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    npv_vec(cp_truth, cp_estimate),
+    npv_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    npv_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 test_that('Two class weighted - sklearn equivalent', {
@@ -96,3 +119,4 @@ test_that('Multi class weighted - sklearn equivalent', {
     py_res$case_weight$macro
   )
 })
+

--- a/tests/testthat/test-class-npv.R
+++ b/tests/testthat/test-class-npv.R
@@ -84,13 +84,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    npv_vec(cp_truth, cp_estimate),
+    npv_vec(fct_truth, cp_estimate),
     npv_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    npv_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    npv_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    accuracy_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-ppv.R
+++ b/tests/testthat/test-class-ppv.R
@@ -115,3 +115,26 @@ test_that('Multi class weighted - sklearn equivalent', {
     py_res$case_weight$macro
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    ppv_vec(cp_truth, cp_estimate),
+    ppv_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    ppv_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-class-ppv.R
+++ b/tests/testthat/test-class-ppv.R
@@ -129,12 +129,17 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    ppv_vec(cp_truth, cp_estimate),
+    ppv_vec(fct_truth, cp_estimate),
     ppv_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    ppv_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    ppv_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    ppv_vec(cp_truth, cp_estimate)
   )
 })

--- a/tests/testthat/test-class-precision.R
+++ b/tests/testthat/test-class-precision.R
@@ -76,6 +76,29 @@ test_that("`NA` is still returned if there are some undefined precision values b
   expect_warning(precision_vec(truth, estimate, na_rm = FALSE), NA)
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    precision_vec(cp_truth, cp_estimate),
+    precision_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    precision_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # sklearn compare --------------------------------------------------------------
 
 test_that('Two class - sklearn equivalent', {

--- a/tests/testthat/test-class-precision.R
+++ b/tests/testthat/test-class-precision.R
@@ -89,13 +89,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    precision_vec(cp_truth, cp_estimate),
+    precision_vec(fct_truth, cp_estimate),
     precision_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    precision_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    precision_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    precision_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-recall.R
+++ b/tests/testthat/test-class-recall.R
@@ -77,13 +77,18 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    recall_vec(cp_truth, cp_estimate),
+    recall_vec(fct_truth, cp_estimate),
     recall_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    recall_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    recall_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    recall_vec(cp_truth, cp_estimate)
   )
 })
 

--- a/tests/testthat/test-class-recall.R
+++ b/tests/testthat/test-class-recall.R
@@ -64,6 +64,30 @@ test_that("`NA` is still returned if there are some undefined recall values but 
   expect_warning(recall_vec(truth, estimate, na_rm = FALSE), NA)
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    recall_vec(cp_truth, cp_estimate),
+    recall_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    recall_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
+
 # sklearn compare --------------------------------------------------------------
 
 test_that('Two class - sklearn equivalent', {
@@ -125,3 +149,4 @@ test_that('Multi class case weighted - sklearn equivalent', {
     py_res$case_weight$weighted
   )
 })
+

--- a/tests/testthat/test-class-sens.R
+++ b/tests/testthat/test-class-sens.R
@@ -193,3 +193,26 @@ test_that("`sensitivity()` has a metric name unique to it (#232)", {
     "sensitivity"
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    sensitivity_vec(cp_truth, cp_estimate),
+    sensitivity_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    sensitivity_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-class-sens.R
+++ b/tests/testthat/test-class-sens.R
@@ -207,12 +207,17 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    sensitivity_vec(cp_truth, cp_estimate),
+    sensitivity_vec(fct_truth, cp_estimate),
     sensitivity_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    sensitivity_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    sensitivity_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    sensitivity_vec(cp_truth, cp_estimate)
   )
 })

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -147,12 +147,17 @@ test_that("work with class_pred input", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    specificity_vec(cp_truth, cp_estimate),
+    specificity_vec(fct_truth, cp_estimate),
     specificity_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    specificity_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    specificity_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    specificity_vec(cp_truth, cp_estimate)
   )
 })

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -133,3 +133,26 @@ test_that("`specificity()` has a metric name unique to it (#232)", {
     "specificity"
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
+
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  fct_estimate <- two_class_example$predicted
+  fct_estimate[2] <- NA
+
+  expect_identical(
+    specificity_vec(cp_truth, cp_estimate),
+    specificity_vec(fct_truth, fct_estimate)
+  )
+
+  expect_identical(
+    specificity_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-average_precision.R
+++ b/tests/testthat/test-prob-average_precision.R
@@ -92,3 +92,23 @@ test_that('Multiclass weighted average precision matches sklearn', {
     py$case_weight$macro_weighted
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    average_precision_vec(cp_truth, estimate),
+    average_precision_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    average_precision_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-average_precision.R
+++ b/tests/testthat/test-prob-average_precision.R
@@ -93,7 +93,7 @@ test_that('Multiclass weighted average precision matches sklearn', {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -102,13 +102,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    average_precision_vec(cp_truth, estimate),
-    average_precision_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    average_precision_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    average_precision_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-brier-class.R
+++ b/tests/testthat/test-prob-brier-class.R
@@ -70,7 +70,7 @@ test_that('basic results', {
 
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -79,13 +79,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    brier_class_vec(cp_truth, estimate),
-    brier_class_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    brier_class_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    brier_class_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-brier-class.R
+++ b/tests/testthat/test-prob-brier-class.R
@@ -70,3 +70,22 @@ test_that('basic results', {
 
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    brier_class_vec(cp_truth, estimate),
+    brier_class_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    brier_class_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-classification_cost.R
+++ b/tests/testthat/test-prob-classification_cost.R
@@ -347,7 +347,7 @@ test_that("multiclass - uses case weights", {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -356,13 +356,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    classification_cost_vec(cp_truth, estimate),
-    classification_cost_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    classification_cost_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    classification_cost_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-classification_cost.R
+++ b/tests/testthat/test-prob-classification_cost.R
@@ -346,3 +346,23 @@ test_that("multiclass - uses case weights", {
     exp_cost
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    classification_cost_vec(cp_truth, estimate),
+    classification_cost_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    classification_cost_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-gain_capture.R
+++ b/tests/testthat/test-prob-gain_capture.R
@@ -132,3 +132,23 @@ test_that("multiclass macro / macro_weighted - case weights are applied correctl
     gain_capture(hpc_f1_expanded, obs, VF:L, estimator = estimator)[[".estimate"]]
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    gain_capture_vec(cp_truth, estimate),
+    gain_capture_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    gain_capture_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-gain_capture.R
+++ b/tests/testthat/test-prob-gain_capture.R
@@ -133,7 +133,7 @@ test_that("multiclass macro / macro_weighted - case weights are applied correctl
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -142,13 +142,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    gain_capture_vec(cp_truth, estimate),
-    gain_capture_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    gain_capture_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    gain_capture_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -207,3 +207,23 @@ test_that("gain_curve() works with hardhat case weights", {
 
   expect_identical(curve1, curve2)
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    gain_curve_vec(cp_truth, estimate),
+    gain_curve_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    gain_curve_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -208,7 +208,7 @@ test_that("gain_curve() works with hardhat case weights", {
   expect_identical(curve1, curve2)
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -217,13 +217,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    gain_curve_vec(cp_truth, estimate),
-    gain_curve_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    gain_curve_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    gain_curve_vec_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-lift_curve.R
+++ b/tests/testthat/test-prob-lift_curve.R
@@ -156,7 +156,7 @@ test_that("lift_curve() works with case weights and multiclass (ideally, frequen
   expect_identical(out, expect)
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -165,13 +165,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    lift_curve_vec(cp_truth, estimate),
-    lift_curve_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    lift_curve_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    lift_curve_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-lift_curve.R
+++ b/tests/testthat/test-prob-lift_curve.R
@@ -155,3 +155,23 @@ test_that("lift_curve() works with case weights and multiclass (ideally, frequen
   expect_s3_class(out, "lift_df")
   expect_identical(out, expect)
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    lift_curve_vec(cp_truth, estimate),
+    lift_curve_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    lift_curve_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-mn_log_loss.R
+++ b/tests/testthat/test-prob-mn_log_loss.R
@@ -88,7 +88,7 @@ test_that("mn_log_loss() applies the min/max rule when a 'non-event' has probabi
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -97,14 +97,9 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    mn_log_loss_vec(cp_truth, estimate),
-    mn_log_loss_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    mn_log_loss_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    mn_log_loss_vec(cp_truth, estimate)
   )
 })
 

--- a/tests/testthat/test-prob-mn_log_loss.R
+++ b/tests/testthat/test-prob-mn_log_loss.R
@@ -88,6 +88,26 @@ test_that("mn_log_loss() applies the min/max rule when a 'non-event' has probabi
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    mn_log_loss_vec(cp_truth, estimate),
+    mn_log_loss_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    mn_log_loss_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 test_that('Two class - sklearn equivalent', {

--- a/tests/testthat/test-prob-pr_auc.R
+++ b/tests/testthat/test-prob-pr_auc.R
@@ -75,7 +75,7 @@ test_that("grouped multiclass (one-vs-all) weighted example matches expanded equ
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -84,13 +84,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    pr_auc_vec(cp_truth, estimate),
-    pr_auc_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    pr_auc_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    pr_auc_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-pr_auc.R
+++ b/tests/testthat/test-prob-pr_auc.R
@@ -74,3 +74,23 @@ test_that("grouped multiclass (one-vs-all) weighted example matches expanded equ
     pr_auc(hpc_cv_expanded, obs, VF:L, estimator = "macro_weighted")
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    pr_auc_vec(cp_truth, estimate),
+    pr_auc_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    pr_auc_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-pr_curve.R
+++ b/tests/testthat/test-prob-pr_curve.R
@@ -228,6 +228,26 @@ test_that("zero weights don't affect the curve", {
   )
 })
 
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    pr_curve_vec(cp_truth, estimate),
+    pr_curve_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    pr_curve_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+
 # ------------------------------------------------------------------------------
 
 test_that("Binary results are the same as scikit-learn", {

--- a/tests/testthat/test-prob-pr_curve.R
+++ b/tests/testthat/test-prob-pr_curve.R
@@ -228,7 +228,7 @@ test_that("zero weights don't affect the curve", {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -237,14 +237,9 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    pr_curve_vec(cp_truth, estimate),
-    pr_curve_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    pr_curve_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    pr_curve_vec(cp_truth, estimate)
   )
 })
 

--- a/tests/testthat/test-prob-roc_auc.R
+++ b/tests/testthat/test-prob-roc_auc.R
@@ -382,3 +382,23 @@ test_that("roc_auc() - `options` is deprecated", {
     )
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    roc_auc_vec(cp_truth, estimate),
+    roc_auc_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    roc_auc_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-roc_auc.R
+++ b/tests/testthat/test-prob-roc_auc.R
@@ -383,7 +383,7 @@ test_that("roc_auc() - `options` is deprecated", {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -392,13 +392,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    roc_auc_vec(cp_truth, estimate),
-    roc_auc_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    roc_auc_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    roc_auc_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -66,3 +66,24 @@ test_that("roc_aunp() - `options` is deprecated", {
     )
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- as.matrix(two_class_example[c("Class1", "Class2")])
+
+  expect_identical(
+    roc_aunp_vec(cp_truth, estimate),
+    roc_aunp_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    roc_aunp_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -76,14 +76,9 @@ test_that("work with class_pred input", {
 
   estimate <- as.matrix(two_class_example[c("Class1", "Class2")])
 
-  expect_identical(
-    roc_aunp_vec(cp_truth, estimate),
-    roc_aunp_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    roc_aunp_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    roc_aunp_vec(cp_truth, estimate)
   )
 })
 

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -66,3 +66,24 @@ test_that("roc_aunu() - `options` is deprecated", {
     )
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- as.matrix(two_class_example[c("Class1", "Class2")])
+
+  expect_identical(
+    roc_aunu_vec(cp_truth, estimate),
+    roc_aunu_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    roc_aunu_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})
+

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -67,7 +67,7 @@ test_that("roc_aunu() - `options` is deprecated", {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -76,14 +76,8 @@ test_that("work with class_pred input", {
 
   estimate <- as.matrix(two_class_example[c("Class1", "Class2")])
 
-  expect_identical(
-    roc_aunu_vec(cp_truth, estimate),
-    roc_aunu_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    roc_aunu_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    roc_aunu_vec(cp_truth, estimate)
   )
 })
-

--- a/tests/testthat/test-prob-roc_curve.R
+++ b/tests/testthat/test-prob-roc_curve.R
@@ -158,3 +158,23 @@ test_that("roc_curve() - `options` is deprecated", {
     roc_curve(two_class_example, truth, Class1)
   )
 })
+
+test_that("work with class_pred input", {
+  skip_if_not_installed("probably")
+
+  cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
+  fct_truth <- two_class_example$truth
+  fct_truth[1] <- NA
+
+  estimate <- two_class_example$Class1
+
+  expect_identical(
+    roc_curve_vec(cp_truth, estimate),
+    roc_curve_vec(fct_truth, estimate)
+  )
+
+  expect_identical(
+    roc_curve_vec(cp_truth, estimate, na_rm = FALSE),
+    NA_real_
+  )
+})

--- a/tests/testthat/test-prob-roc_curve.R
+++ b/tests/testthat/test-prob-roc_curve.R
@@ -159,7 +159,7 @@ test_that("roc_curve() - `options` is deprecated", {
   )
 })
 
-test_that("work with class_pred input", {
+test_that("errors with class_pred input", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
@@ -168,13 +168,8 @@ test_that("work with class_pred input", {
 
   estimate <- two_class_example$Class1
 
-  expect_identical(
-    roc_curve_vec(cp_truth, estimate),
-    roc_curve_vec(fct_truth, estimate)
-  )
-
-  expect_identical(
-    roc_curve_vec(cp_truth, estimate, na_rm = FALSE),
-    NA_real_
+  expect_snapshot(
+    error = TRUE,
+    roc_curve_vec(cp_truth, estimate)
   )
 })

--- a/tests/testthat/test-probably.R
+++ b/tests/testthat/test-probably.R
@@ -11,58 +11,48 @@ test_that("`class_pred` can be converted to `factor` when computing metrics", {
   fct_estimate[2] <- NA
 
   expect_identical(
-    accuracy_vec(cp_truth, cp_estimate),
+    accuracy_vec(fct_truth, cp_estimate),
     accuracy_vec(fct_truth, fct_estimate)
   )
 
   expect_identical(
-    accuracy_vec(cp_truth, cp_estimate, na_rm = FALSE),
+    accuracy_vec(fct_truth, cp_estimate, na_rm = FALSE),
     NA_real_
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    accuracy_vec(cp_truth, cp_estimate)
   )
 })
 
-test_that("`class_pred` can be converted to `factor` with `conf_mat()`", {
+test_that("`class_pred` errors when passed to `conf_mat()`", {
   skip_if_not_installed("probably")
 
   cp_hpc_cv <- hpc_cv
   cp_hpc_cv$obs <- probably::as_class_pred(cp_hpc_cv$obs, which = 1)
   cp_hpc_cv$pred <- probably::as_class_pred(cp_hpc_cv$pred, which = 2)
 
-  fct_hpc_cv <- hpc_cv
-  fct_hpc_cv$obs[1] <- NA
-  fct_hpc_cv$pred[2] <- NA
-
-  expect_identical(
-    conf_mat(cp_hpc_cv, obs, pred),
-    conf_mat(fct_hpc_cv, obs, pred)
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(cp_hpc_cv, obs, pred)
   )
-  expect_identical(
-    conf_mat(dplyr::group_by(cp_hpc_cv, Resample), obs, pred),
-    conf_mat(dplyr::group_by(fct_hpc_cv, Resample), obs, pred)
+
+  expect_snapshot(
+    error = TRUE,
+    conf_mat(dplyr::group_by(cp_hpc_cv, Resample), obs, pred)
   )
 })
 
-test_that("`class_pred` can be converted to `factor` with `metrics()`", {
+test_that("`class_pred` errors when passed to `metrics()`", {
   skip_if_not_installed("probably")
 
   cp_truth <- probably::as_class_pred(two_class_example$truth, which = 1)
   cp_estimate <- probably::as_class_pred(two_class_example$predicted, which = 2)
   cp_df <- data.frame(truth = cp_truth, estimate = cp_estimate, class1 = two_class_example$Class1)
 
-  fct_truth <- two_class_example$truth
-  fct_truth[1] <- NA
-
-  fct_estimate <- two_class_example$predicted
-  fct_estimate[2] <- NA
-
-  fct_df <- data.frame(truth = fct_truth, estimate = fct_estimate, class1 = two_class_example$Class1)
-
-  expect_identical(
-    metrics(cp_df, truth, estimate, class1),
-    metrics(fct_df, truth, estimate, class1)
-  )
-  expect_identical(
-    metrics(cp_df, truth, estimate, class1, na_rm = FALSE)[[".estimate"]],
-    rep(NA_real_, 4)
+  expect_snapshot(
+    error = TRUE,
+    metrics(cp_df, truth, estimate, class1)
   )
 })


### PR DESCRIPTION
This PR aims to close #341 

It
- uses `as_factor_from_class_pred()` inside each `_vec()` function. (i would have liked to have done it in the metric summarizers but then `_vec()` would work.
- Adds tests for each metric that supports class_pred
- Removed now redudant calls to `as_factor_from_class_pred()` https://github.com/tidymodels/yardstick/commit/1a1ce89b2718bf696a8cddd814cda12ccbb1dc9e

``` r
library(yardstick)

df <- tibble::tibble(
  truth = probably::class_pred(factor(c("a", "b", "a", "c"))), 
  estimate = factor(c("a", "c", "a", "b"))
)

accuracy(df, truth, estimate)
#> # A tibble: 1 × 3
#>   .metric  .estimator .estimate
#>   <chr>    <chr>          <dbl>
#> 1 accuracy binary           0.5

accuracy_vec(df$truth, df$estimate)
#> [1] 0.5
```