### PR TITLE
cache known selections while tuning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: yardstick
 Title: Tidy Characterizations of Model Performance
-Version: 1.2.0.9000
+Version: 1.2.0.9001
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = "aut"),
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     tibble,
     tidyselect (>= 1.2.0),
     utils,
-    vctrs (>= 0.5.0)
+    vctrs (>= 0.5.0),
+    withr
 Suggests: 
     covr,
     crayon,

--- a/R/template.R
+++ b/R/template.R
@@ -759,6 +759,14 @@ yardstick_eval_select <- function(expr,
                                   error_call = caller_env()) {
   check_dots_empty(call = error_call)
 
+  if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), "name")) {
+    expr_name <- as_name(expr)
+
+    if (is_known_selection(expr_name)) {
+      return(get_known_selection(expr_name))
+    }
+  }
+
   out <- tidyselect::eval_select(
     expr = expr,
     data = data,
@@ -774,12 +782,24 @@ yardstick_eval_select <- function(expr,
     abort(message, call = error_call)
   }
 
+  set_known_selection(as_name(expr), out)
+
   out
 }
 
 yardstick_eval_select_dots <- function(...,
                                        data,
                                        error_call = caller_env()) {
+  expr <- quo(!!substitute(...))
+
+  if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), c("name", "call"))) {
+    expr_label <- as_label(expr)
+
+    if (is_known_selection(expr_label)) {
+      return(get_known_selection(expr_label))
+    }
+  }
+
   out <- tidyselect::eval_select(
     expr = expr(c(...)),
     data = data,
@@ -791,5 +811,78 @@ yardstick_eval_select_dots <- function(...,
 
   out <- names(out)
 
+  set_known_selection(as_label(expr), out)
+
   out
+}
+
+# store known selections (#428) ------------------------------------------------
+is_known_selection <- function(expr_name) {
+  if (!catalog_is_available() || !in_tuning_env()) {
+    return(FALSE)
+  }
+
+  known_selections <- ns_env("tune")$tune_env$known_selections
+
+  expr_name %in% names(known_selections)
+}
+
+get_known_selection <- function(expr_name) {
+  known_selections <- ns_env("tune")$tune_env$known_selections
+
+  known_selections[[expr_name]]
+}
+
+set_known_selection <- function(expr_name, out) {
+  if (!catalog_is_available() || !in_tuning_env()) {
+    return(invisible())
+  }
+
+  tune_env <- ns_env("tune")$tune_env
+
+  if (is.null(tune_env$known_selections)) {
+    init_known_selection(tune_env)
+  }
+
+  tune_env$known_selections[[expr_name]] <- out
+
+  invisible()
+}
+
+init_known_selection <- function(tune_env) {
+  withr::defer(
+    env_bind(tune_env, known_selections = NULL),
+    envir = tune_env$progress_env
+  )
+}
+
+# `catalog_is_available()` defines the per-session condition for whether we
+# can store known selections, while `in_tuning_env()` defines the
+# per-tuning instance of the condition. we want to store known selections:
+# 1) when tune's cataloging machinery is available
+# 2) when called inside of a tuning env, regardless of whether the catalog is
+#    being used to log errors.
+# notably, we don't do so when yardstick functions are called outside of
+# tune, in which case the overhead is `in_tuning_env()` after the first call.
+#
+# set up as a function with local variables so that we only have to run
+# `is_installed()` and `packageVersion()` once.
+catalog_is_available <-
+  local({
+    tune_is_installed <- NULL
+    tune_version_is_sufficient <- FALSE
+
+    function() {
+      if (is.null(tune_is_installed)) {
+        tune_is_installed <<- is_installed("tune")
+        if (tune_is_installed) {
+          tune_version_is_sufficient <<- packageVersion("tune") > "1.1.0"
+        }
+      }
+      tune_is_installed && tune_version_is_sufficient
+    }
+  })
+
+in_tuning_env <- function(tune_env = ns_env("tune")$tune_env) {
+  !is.null(tune_env$progress_env)
 }

--- a/R/template.R
+++ b/R/template.R
@@ -876,7 +876,7 @@ catalog_is_available <-
       if (is.null(tune_is_installed)) {
         tune_is_installed <<- is_installed("tune")
         if (tune_is_installed) {
-          tune_version_is_sufficient <<- packageVersion("tune") > "1.1.0"
+          tune_version_is_sufficient <<- utils::packageVersion("tune") > "1.1.0"
         }
       }
       tune_is_installed && tune_version_is_sufficient

--- a/R/template.R
+++ b/R/template.R
@@ -758,6 +758,7 @@ yardstick_eval_select <- function(expr,
                                   ...,
                                   error_call = caller_env()) {
   check_dots_empty(call = error_call)
+  expr_name <- "init"
 
   if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), "name")) {
     expr_name <- as_name(expr)
@@ -782,7 +783,7 @@ yardstick_eval_select <- function(expr,
     abort(message, call = error_call)
   }
 
-  set_known_selection(as_name(expr), out)
+  set_known_selection(expr_name, out)
 
   out
 }
@@ -791,6 +792,7 @@ yardstick_eval_select_dots <- function(...,
                                        data,
                                        error_call = caller_env()) {
   expr <- quo(!!substitute(...))
+  expr_label <- "init"
 
   if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), c("name", "call"))) {
     expr_label <- as_label(expr)
@@ -811,7 +813,7 @@ yardstick_eval_select_dots <- function(...,
 
   out <- names(out)
 
-  set_known_selection(as_label(expr), out)
+  set_known_selection(expr_label, out)
 
   out
 }

--- a/R/template.R
+++ b/R/template.R
@@ -758,7 +758,6 @@ yardstick_eval_select <- function(expr,
                                   ...,
                                   error_call = caller_env()) {
   check_dots_empty(call = error_call)
-  expr_name <- "init"
 
   if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), "name")) {
     expr_name <- as_name(expr)
@@ -783,7 +782,7 @@ yardstick_eval_select <- function(expr,
     abort(message, call = error_call)
   }
 
-  set_known_selection(expr_name, out)
+  set_known_selection(as_name(expr), out)
 
   out
 }
@@ -792,7 +791,6 @@ yardstick_eval_select_dots <- function(...,
                                        data,
                                        error_call = caller_env()) {
   expr <- quo(!!substitute(...))
-  expr_label <- "init"
 
   if (!quo_is_missing(expr) && inherits(quo_get_expr(expr), c("name", "call"))) {
     expr_label <- as_label(expr)
@@ -813,7 +811,7 @@ yardstick_eval_select_dots <- function(...,
 
   out <- names(out)
 
-  set_known_selection(expr_label, out)
+  set_known_selection(as_label(expr), out)
 
   out
 }

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -1719,3 +1719,12 @@ test_that("curve_survival_metric_summarizer() handles column name collisions", {
 
   expect_identical(roc_survival_curve_res, roc_survival_curve_exp)
 })
+
+test_that("known selections don't affect selection without tune", {
+  # yardstick's CI reliably does not have tune installed
+  skip_if(rlang::is_installed("tune"), "tune is installed")
+
+  expect_silent({
+    test_res <- rmse(solubility_test, solubility, prediction)
+  })
+})


### PR DESCRIPTION
In tune, `yardstick_eval_select()` is called `n_resamples * n_grid_points * n_metrics` times for each column selection input. Within a tuning process, the `expr` passed to `eval_select()` uniquely identifies the selection result. We can thus cache those known selections after they're evaluated once and then retrieve them for the remainder of the tuning process. 

In context, this can have a substantial impact on time to evaluate against resamples, especially with quick model fits and many resamples / grid points. With this PR:

``` r
bench::mark(
  new = 
    fit_resamples(
      logistic_reg(),
      Class ~ .,
      bootstraps(two_class_dat, 1000)
    )
)
#> # A tibble: 1 × 13
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 new           10.7s  10.7s    0.0935    2.19GB     3.18     1    34
#> # ℹ 5 more variables: total_time <bch:tm>, result <list>,
#> #   memory <list>, time <list>, gc <list>
```

With `main` dev:

``` r
#> # A tibble: 1 × 13
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 old           12.4s    12.4s    0.0805     2.2GB     4.59     1    57
#> # ℹ 5 more variables: total_time <bch:tm>, result <list>, memory <list>,
#> #   time <list>, gc <list>
```

When this machinery isn't kicked in, i.e. when yardstick functions are called outside of a tune function, the overhead is just the time that `in_tuning_env()` takes (after the first call to a yardstick function, per session):

``` r
bench::mark(
    in_tuning_env()
)
#> # A tibble: 1 × 13
#>   expression           min  median `itr/sec` mem_alloc `gc/sec` n_itr
#>   <bch:expr>      <bch:tm> <bch:t>     <dbl> <bch:byt>    <dbl> <int>
#> 1 in_tuning_env()   1.97µs  2.54µs   334133.        0B        0 10000
#> # ℹ 6 more variables: n_gc <dbl>, total_time <bch:tm>,
#> #   result <list>, memory <list>, time <list>, gc <list>
```

PR 1/2: further testing heading to extratests in a moment!