### PR TITLE
use case_weights in roc_curve calculations

### DIFF
--- a/R/surv-roc_auc_survival.R
+++ b/R/surv-roc_auc_survival.R
@@ -94,7 +94,12 @@ roc_auc_survival_vec <- function(truth,
                                  case_weights = NULL,
                                  ...) {
   # No checking since roc_curve_survival_vec() does checking
-  curve <- roc_curve_survival_vec(truth, estimate)
+  curve <- roc_curve_survival_vec(
+    truth = truth,
+    estimate = estimate,
+    na_rm = na_rm,
+    case_weights = case_weights
+  )
 
   curve %>%
     dplyr::group_by(.eval_time) %>%

--- a/R/surv-roc_curve_survival.R
+++ b/R/surv-roc_curve_survival.R
@@ -189,8 +189,8 @@ roc_curve_survival_impl_one <- function(event_time, delta, data, case_weights) {
   n <- nrow(data)
   multiplier <- delta / (n * data$.weight_censored)
 
-  sensitivity_denom <- sum(obs_time_le_time * multiplier, na.rm = TRUE)
-  specificity_denom <- sum(obs_time_gt_time, na.rm = TRUE)
+  sensitivity_denom <- sum(obs_time_le_time * multiplier * x$case_weights, na.rm = TRUE)
+  specificity_denom <- sum(obs_time_gt_time * x$case_weights, na.rm = TRUE)
 
   data_df <- data.frame(
     le_time = obs_time_le_time,

--- a/R/surv-roc_curve_survival.R
+++ b/R/surv-roc_curve_survival.R
@@ -189,8 +189,8 @@ roc_curve_survival_impl_one <- function(event_time, delta, data, case_weights) {
   n <- nrow(data)
   multiplier <- delta / (n * data$.weight_censored)
 
-  sensitivity_denom <- sum(obs_time_le_time * multiplier * x$case_weights, na.rm = TRUE)
-  specificity_denom <- sum(obs_time_gt_time * x$case_weights, na.rm = TRUE)
+  sensitivity_denom <- sum(obs_time_le_time * multiplier * case_weights, na.rm = TRUE)
+  specificity_denom <- sum(obs_time_gt_time * case_weights, na.rm = TRUE)
 
   data_df <- data.frame(
     le_time = obs_time_le_time,

--- a/tests/testthat/test-surv-roc_auc_survival.R
+++ b/tests/testthat/test-surv-roc_auc_survival.R
@@ -21,6 +21,27 @@ test_that("roc_curve_auc() calculations", {
   )
 })
 
+# case weights -----------------------------------------------------------------
+
+test_that("case weights are applied", {
+  wts_res <- lung_surv %>%
+    dplyr::mutate(wts = hardhat::frequency_weights(rep(1:0, c(128, 100)))) %>%
+    roc_auc_survival(
+      truth = surv_obj,
+      .pred,
+      case_weights = wts
+    )
+
+  subset_res <- lung_surv %>%
+    dplyr::slice(1:128) %>%
+    roc_auc_survival(
+      truth = surv_obj,
+      .pred
+    )
+
+  expect_identical(subset_res, wts_res)
+})
+
 # self checking ----------------------------------------------------------------
 
 test_that("snapshot equivalent", {

--- a/tests/testthat/test-surv-roc_curve_survival.R
+++ b/tests/testthat/test-surv-roc_curve_survival.R
@@ -37,6 +37,27 @@ test_that("roc_curve_survival works", {
   }
 })
 
+# case weights -----------------------------------------------------------------
+
+test_that("case weights are applied", {
+  wts_res <- lung_surv %>%
+    dplyr::mutate(wts = hardhat::frequency_weights(rep(1:0, c(128, 100)))) %>%
+    roc_curve_survival(
+      truth = surv_obj,
+      .pred,
+      case_weights = wts
+    )
+
+  subset_res <- lung_surv %>%
+    dplyr::slice(1:128) %>%
+    roc_curve_survival(
+      truth = surv_obj,
+      .pred
+    )
+
+  expect_identical(subset_res, wts_res)
+})
+
 # self checking ----------------------------------------------------------------
 
 test_that("snapshot equivalent", {


### PR DESCRIPTION
This PR adds `case_weights` support for survival ROC curve calculations, `roc_curve_survival()` and `roc_auc_survival()`.

This addition in modeled after the way we incorporate case weights for normal ROC curve calculations, as wee here: https://github.com/tidymodels/yardstick/blob/main/R/prob-binary-thresholds.R.

``` r
library(yardstick)
library(dplyr)

res <- lung_surv %>%
  roc_curve_survival(
    truth = surv_obj,
    .pred
  )

wts_res <- lung_surv %>%
  mutate(wts = hardhat::frequency_weights(rep(1:0, c(128, 100)))) %>%
  roc_curve_survival(
    truth = surv_obj,
    .pred, 
    case_weights = wts
  )

identical(res, wts_res)
#> [1] FALSE

subset_res <- lung_surv %>%
  slice(1:128) %>%
  roc_curve_survival(
    truth = surv_obj,
    .pred
  )

identical(subset_res, wts_res)
#> [1] TRUE
```