### PR TITLE
Apply stricter .eval_time checking for dynamic survival metrics

### DIFF
--- a/R/validation.R
+++ b/R/validation.R
@@ -203,6 +203,21 @@ validate_surv_truth_list_estimate <- function(truth,
       call = call
     )
   }
+
+  all_eval_times_list <- lapply(estimate, function(x) x$.eval_time)
+  all_eval_times <- unlist(all_eval_times_list)
+
+  if (any(all_eval_times < 0)) {
+    offenders <- unique(all_eval_times[all_eval_times < 0])
+
+    cli::cli_abort(
+      c(
+        x = "Negative values of {.field .eval_time} are not allowed.",
+        i = "The following negative values were found: {.val {offenders}}."
+      ),
+      call = call
+    )
+  }
 }
 
 validate_surv_truth_numeric_estimate <- function(truth,

--- a/R/validation.R
+++ b/R/validation.R
@@ -207,6 +207,15 @@ validate_surv_truth_list_estimate <- function(truth,
   all_eval_times_list <- lapply(estimate, function(x) x$.eval_time)
   all_eval_times <- unlist(all_eval_times_list)
 
+  if (any(is.na(all_eval_times))) {
+    cli::cli_abort(
+      c(
+        x = "Missing values in {.field .eval_time} are not allowed."
+      ),
+      call = call
+    )
+  }
+
   if (any(all_eval_times < 0)) {
     offenders <- unique(all_eval_times[all_eval_times < 0])
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -248,6 +248,18 @@ validate_surv_truth_list_estimate <- function(truth,
       call = call
     )
   }
+
+  any_not_in_order <- any(
+    vapply(all_eval_times_list, function(x) is.unsorted(x), logical(1))
+  )
+  if (any_not_in_order) {
+    cli::cli_abort(
+      c(
+        x = "Values of {.field .eval_time} must be in increasing order."
+      ),
+      call = call
+    )
+  }
 }
 
 validate_surv_truth_numeric_estimate <- function(truth,

--- a/R/validation.R
+++ b/R/validation.R
@@ -227,6 +227,15 @@ validate_surv_truth_list_estimate <- function(truth,
       call = call
     )
   }
+
+  if (any(is.infinite(all_eval_times))) {
+    cli::cli_abort(
+      c(
+        x = "Infinite values of {.field .eval_time} are not allowed."
+      ),
+      call = call
+    )
+  }
 }
 
 validate_surv_truth_numeric_estimate <- function(truth,

--- a/R/validation.R
+++ b/R/validation.R
@@ -236,6 +236,18 @@ validate_surv_truth_list_estimate <- function(truth,
       call = call
     )
   }
+
+  any_duplicates <- any(
+    vapply(all_eval_times_list, function(x) any(table(x) > 1), logical(1))
+  )
+  if (any_duplicates) {
+    cli::cli_abort(
+      c(
+        x = "Duplicate values of {.field .eval_time} are not allowed."
+      ),
+      call = call
+    )
+  }
 }
 
 validate_surv_truth_numeric_estimate <- function(truth,

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -274,6 +274,15 @@
       Error:
       x Infinite values of .eval_time are not allowed.
 
+---
+
+    Code
+      validate_surv_truth_list_estimate(lung_surv_duplicate$surv_obj,
+      lung_surv_duplicate$.pred)
+    Condition
+      Error:
+      x Duplicate values of .eval_time are not allowed.
+
 # validate_case_weights errors as expected
 
     Code

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -258,6 +258,14 @@
       x Negative values of .eval_time are not allowed.
       i The following negative values were found: -100.
 
+---
+
+    Code
+      validate_surv_truth_list_estimate(lung_surv_na$surv_obj, lung_surv_na$.pred)
+    Condition
+      Error:
+      x Missing values in .eval_time are not allowed.
+
 # validate_case_weights errors as expected
 
     Code

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -283,6 +283,15 @@
       Error:
       x Duplicate values of .eval_time are not allowed.
 
+---
+
+    Code
+      validate_surv_truth_list_estimate(lung_surv_order$surv_obj, lung_surv_order$
+        .pred)
+    Condition
+      Error:
+      x Values of .eval_time must be in increasing order.
+
 # validate_case_weights errors as expected
 
     Code

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -249,6 +249,15 @@
       Error:
       ! `estimate` should be a list, not a a double vector.
 
+---
+
+    Code
+      validate_surv_truth_list_estimate(lung_surv_neg$surv_obj, lung_surv_neg$.pred)
+    Condition
+      Error:
+      x Negative values of .eval_time are not allowed.
+      i The following negative values were found: -100.
+
 # validate_case_weights errors as expected
 
     Code

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -266,6 +266,14 @@
       Error:
       x Missing values in .eval_time are not allowed.
 
+---
+
+    Code
+      validate_surv_truth_list_estimate(lung_surv_inf$surv_obj, lung_surv_inf$.pred)
+    Condition
+      Error:
+      x Infinite values of .eval_time are not allowed.
+
 # validate_case_weights errors as expected
 
     Code

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -427,6 +427,18 @@ test_that("validate_surv_truth_list_estimate errors as expected", {
       lung_surv_duplicate$.pred
     )
   )
+
+  lung_surv_order <- lung_surv
+  lung_surv_order$.pred <- lapply(
+    lung_surv_order$.pred, dplyr::arrange, dplyr::desc(.eval_time)
+  )
+  expect_snapshot(
+    error = TRUE,
+    validate_surv_truth_list_estimate(
+      lung_surv_order$surv_obj,
+      lung_surv_order$.pred
+    )
+  )
 })
 
 test_that("validate_case_weights errors as expected", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -397,6 +397,16 @@ test_that("validate_surv_truth_list_estimate errors as expected", {
       lung_surv_neg$.pred
     )
   )
+
+  lung_surv_na <- lung_surv
+  lung_surv_na$.pred[[1]]$.eval_time[1] <- NA
+  expect_snapshot(
+    error = TRUE,
+    validate_surv_truth_list_estimate(
+      lung_surv_na$surv_obj,
+      lung_surv_na$.pred
+    )
+  )
 })
 
 test_that("validate_case_weights errors as expected", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -407,6 +407,16 @@ test_that("validate_surv_truth_list_estimate errors as expected", {
       lung_surv_na$.pred
     )
   )
+
+  lung_surv_inf <- lung_surv
+  lung_surv_inf$.pred[[1]]$.eval_time[1] <- Inf
+  expect_snapshot(
+    error = TRUE,
+    validate_surv_truth_list_estimate(
+      lung_surv_inf$surv_obj,
+      lung_surv_inf$.pred
+    )
+  )
 })
 
 test_that("validate_case_weights errors as expected", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -387,6 +387,16 @@ test_that("validate_surv_truth_list_estimate errors as expected", {
       lung_surv$.pred_time
     )
   )
+
+  lung_surv_neg <- lung_surv
+  lung_surv_neg$.pred[[1]]$.eval_time[1] <- -100
+  expect_snapshot(
+    error = TRUE,
+    validate_surv_truth_list_estimate(
+      lung_surv_neg$surv_obj,
+      lung_surv_neg$.pred
+    )
+  )
 })
 
 test_that("validate_case_weights errors as expected", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -417,6 +417,16 @@ test_that("validate_surv_truth_list_estimate errors as expected", {
       lung_surv_inf$.pred
     )
   )
+
+  lung_surv_duplicate <- lung_surv
+  lung_surv_duplicate$.pred[[1]]$.eval_time[1] <- 200
+  expect_snapshot(
+    error = TRUE,
+    validate_surv_truth_list_estimate(
+      lung_surv_duplicate$surv_obj,
+      lung_surv_duplicate$.pred
+    )
+  )
 })
 
 test_that("validate_case_weights errors as expected", {


### PR DESCRIPTION
to close https://github.com/tidymodels/yardstick/issues/462

``` r
library(yardstick)

brier_survival(lung_surv, truth = surv_obj, .pred)
#> # A tibble: 5 × 4
#>   .metric        .estimator .eval_time .estimate
#>   <chr>          <chr>           <dbl>     <dbl>
#> 1 brier_survival standard          100     0.109
#> 2 brier_survival standard          200     0.194
#> 3 brier_survival standard          300     0.219
#> 4 brier_survival standard          400     0.222
#> 5 brier_survival standard          500     0.197

roc_auc_survival(lung_surv, truth = surv_obj, .pred)
#> # A tibble: 5 × 4
#>   .metric          .estimator .eval_time .estimate
#>   <chr>            <chr>           <dbl>     <dbl>
#> 1 roc_auc_survival standard          100     0.659
#> 2 roc_auc_survival standard          200     0.679
#> 3 roc_auc_survival standard          300     0.688
#> 4 roc_auc_survival standard          400     0.648
#> 5 roc_auc_survival standard          500     0.662

roc_curve_survival(lung_surv, truth = surv_obj, .pred)
#> # A tibble: 650 × 4
#>    .threshold sensitivity specificity .eval_time
#>         <dbl>       <dbl>       <dbl>      <dbl>
#>  1   -Inf          0            1            100
#>  2      0.615      0            0.995        100
#>  3      0.723      0.0334       0.985        100
#>  4      0.727      0.133        0.985        100
#>  5      0.730      0.167        0.985        100
#>  6      0.732      0.233        0.980        100
#>  7      0.739      0.233        0.969        100
#>  8      0.741      0.267        0.964        100
#>  9      0.746      0.267        0.959        100
#> 10      0.748      0.267        0.954        100
#> # ℹ 640 more rows

brier_survival_integrated(lung_surv, truth = surv_obj, .pred)
#> # A tibble: 1 × 3
#>   .metric                   .estimator .estimate
#>   <chr>                     <chr>          <dbl>
#> 1 brier_survival_integrated standard       0.158

lung_surv_neg <- lung_surv
lung_surv_neg$.pred[[1]]$.eval_time[1] <- -100

brier_survival(lung_surv_neg, truth = surv_obj, .pred)
#> Error in `brier_survival()`:
#> ✖ Negative values of .eval_time are not allowed.
#> ℹ The following negative values were found: -100.

roc_auc_survival(lung_surv_neg, truth = surv_obj, .pred)
#> Error in `roc_auc_survival()`:
#> ✖ Negative values of .eval_time are not allowed.
#> ℹ The following negative values were found: -100.

roc_curve_survival(lung_surv_neg, truth = surv_obj, .pred)
#> Error in `roc_curve_survival()`:
#> ✖ Negative values of .eval_time are not allowed.
#> ℹ The following negative values were found: -100.

brier_survival_integrated(lung_surv_neg, truth = surv_obj, .pred)
#> Error in `brier_survival_integrated()`:
#> ✖ Negative values of .eval_time are not allowed.
#> ℹ The following negative values were found: -100.

lung_surv_na <- lung_surv
lung_surv_na$.pred[[1]]$.eval_time[1] <- NA

brier_survival(lung_surv_na, truth = surv_obj, .pred)
#> Error in `brier_survival()`:
#> ✖ Missing values in .eval_time are not allowed.

roc_auc_survival(lung_surv_na, truth = surv_obj, .pred)
#> Error in `roc_auc_survival()`:
#> ✖ Missing values in .eval_time are not allowed.

roc_curve_survival(lung_surv_na, truth = surv_obj, .pred)
#> Error in `roc_curve_survival()`:
#> ✖ Missing values in .eval_time are not allowed.

brier_survival_integrated(lung_surv_na, truth = surv_obj, .pred)
#> Error in `brier_survival_integrated()`:
#> ✖ Missing values in .eval_time are not allowed.

lung_surv_inf <- lung_surv
lung_surv_inf$.pred[[1]]$.eval_time[1] <- Inf

brier_survival(lung_surv_inf, truth = surv_obj, .pred)
#> Error in `brier_survival()`:
#> ✖ Infinite values of .eval_time are not allowed.

roc_auc_survival(lung_surv_inf, truth = surv_obj, .pred)
#> Error in `roc_auc_survival()`:
#> ✖ Infinite values of .eval_time are not allowed.

roc_curve_survival(lung_surv_inf, truth = surv_obj, .pred)
#> Error in `roc_curve_survival()`:
#> ✖ Infinite values of .eval_time are not allowed.

brier_survival_integrated(lung_surv_inf, truth = surv_obj, .pred)
#> Error in `brier_survival_integrated()`:
#> ✖ Infinite values of .eval_time are not allowed.

lung_surv_duplicate <- lung_surv
lung_surv_duplicate$.pred[[1]]$.eval_time[1] <- 200

brier_survival(lung_surv_duplicate, truth = surv_obj, .pred)
#> Error in `brier_survival()`:
#> ✖ Duplicate values of .eval_time are not allowed.

roc_auc_survival(lung_surv_duplicate, truth = surv_obj, .pred)
#> Error in `roc_auc_survival()`:
#> ✖ Duplicate values of .eval_time are not allowed.

roc_curve_survival(lung_surv_duplicate, truth = surv_obj, .pred)
#> Error in `roc_curve_survival()`:
#> ✖ Duplicate values of .eval_time are not allowed.

brier_survival_integrated(lung_surv_duplicate, truth = surv_obj, .pred)
#> Error in `brier_survival_integrated()`:
#> ✖ Duplicate values of .eval_time are not allowed.

lung_surv_order <- lung_surv
lung_surv_order$.pred <- purrr::map(lung_surv_order$.pred, dplyr::arrange, desc(.eval_time))

brier_survival(lung_surv_order, truth = surv_obj, .pred)
#> Error in `brier_survival()`:
#> ✖ Values of .eval_time must be in increasing order.

roc_auc_survival(lung_surv_order, truth = surv_obj, .pred)
#> Error in `roc_auc_survival()`:
#> ✖ Values of .eval_time must be in increasing order.

roc_curve_survival(lung_surv_order, truth = surv_obj, .pred)
#> Error in `roc_curve_survival()`:
#> ✖ Values of .eval_time must be in increasing order.

brier_survival_integrated(lung_surv_order, truth = surv_obj, .pred)
#> Error in `brier_survival_integrated()`:
#> ✖ Values of .eval_time must be in increasing order.
```

<sup>Created on 2023-12-13 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>