### PR TITLE
Bring survival metrics back back

### DIFF
--- a/R/surv-brier_survival.R
+++ b/R/surv-brier_survival.R
@@ -63,7 +63,6 @@
 #'     truth = surv_obj,
 #'     .pred
 #'   )
-#' @keywords internal
 #' @export
 brier_survival <- function(data, ...) {
   UseMethod("brier_survival")

--- a/R/surv-brier_survival_integrated.R
+++ b/R/surv-brier_survival_integrated.R
@@ -51,7 +51,6 @@
 #'     truth = surv_obj,
 #'     .pred
 #'   )
-#' @keywords internal
 #' @export
 brier_survival_integrated <- function(data, ...) {
   UseMethod("brier_survival_integrated")

--- a/R/surv-concordance_survival.R
+++ b/R/surv-concordance_survival.R
@@ -49,7 +49,6 @@
 #'   truth = surv_obj,
 #'   estimate = .pred_time
 #' )
-#' @keywords internal
 #' @export
 concordance_survival <- function(data, ...) {
   UseMethod("concordance_survival")

--- a/R/surv-roc_auc_survival.R
+++ b/R/surv-roc_auc_survival.R
@@ -55,7 +55,6 @@
 #'     truth = surv_obj,
 #'     .pred
 #'   )
-#' @keywords internal
 #' @export
 roc_auc_survival <- function(data, ...) {
   UseMethod("roc_auc_survival")

--- a/R/surv-roc_curve_survival.R
+++ b/R/surv-roc_curve_survival.R
@@ -76,7 +76,6 @@
 #'
 #' # Or use autoplot
 #' autoplot(result)
-#' @keywords internal
 #' @export
 roc_curve_survival <- function(data, ...) {
   UseMethod("roc_curve_survival")

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -75,6 +75,20 @@ reference:
     - equalized_odds
     - equal_opportunity
 
+  - title: Dynamic Survival Metrics
+    contents:
+    - brier_survival
+    - brier_survival_integrated
+    - roc_auc_survival
+
+  - title: Static Survival Metrics
+    contents:
+    - concordance_survival
+
+  - title: Curve Survival Functions
+    contents:
+    - roc_curve_survival
+
   - title: Curve Functions
     contents:
     - roc_curve

--- a/man/brier_survival.Rd
+++ b/man/brier_survival.Rd
@@ -100,4 +100,3 @@ Other dynamic survival metrics:
 Emil Hvitfeldt
 }
 \concept{dynamic survival metrics}
-\keyword{internal}

--- a/man/brier_survival_integrated.Rd
+++ b/man/brier_survival_integrated.Rd
@@ -112,4 +112,3 @@ Other dynamic survival metrics:
 Emil Hvitfeldt
 }
 \concept{dynamic survival metrics}
-\keyword{internal}

--- a/man/concordance_survival.Rd
+++ b/man/concordance_survival.Rd
@@ -98,4 +98,3 @@ Medicine, 15(4), 361-87, 1996.
 Emil Hvitfeldt
 }
 \concept{static survival metrics}
-\keyword{internal}

--- a/man/roc_auc_survival.Rd
+++ b/man/roc_auc_survival.Rd
@@ -107,4 +107,3 @@ Other dynamic survival metrics:
 Emil Hvitfeldt
 }
 \concept{dynamic survival metrics}
-\keyword{internal}

--- a/man/roc_curve_survival.Rd
+++ b/man/roc_curve_survival.Rd
@@ -107,4 +107,3 @@ Compute the area under the ROC survival curve with \code{\link[=roc_auc_survival
 Emil Hvitfeldt
 }
 \concept{survival curve metrics}
-\keyword{internal}


### PR DESCRIPTION
This PR:

- removed `@keywords internal` from all survival metrics
- added them back to the pkgdown

to close #478 