### PR TITLE
Fix formatting of example code in fairness metrics pkgdown docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,4 +48,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/R/fair-demographic_parity.R
+++ b/R/fair-demographic_parity.R
@@ -20,7 +20,6 @@
 #'
 #' @templateVar fn demographic_parity
 #' @templateVar internal_fn detection_prevalence
-#' @templateVar internal_fn [detection_prevalence()]
 #' @template return-fair
 #' @template event-fair
 #' @template examples-fair

--- a/R/fair-equal_opportunity.R
+++ b/R/fair-equal_opportunity.R
@@ -17,7 +17,6 @@
 #'
 #' @templateVar fn equal_opportunity
 #' @templateVar internal_fn sens
-#' @templateVar internal_fn [sens()]
 #' @template return-fair
 #' @template event-fair
 #' @template examples-fair

--- a/man/demographic_parity.Rd
+++ b/man/demographic_parity.Rd
@@ -15,7 +15,7 @@ This function outputs a yardstick \emph{fairness metric} function. Given a
 grouping variable \code{by}, \code{demographic_parity()} will return a yardstick metric
 function that is associated with the data-variable grouping \code{by} and a
 post-processor. The outputted function will first generate a set
-of \code{\link[=detection_prevalence]{detection_prevalence()}} metric values by group before summarizing across
+of detection_prevalence metric values by group before summarizing across
 groups using the post-processing function.
 
 The outputted function only has a data frame method and is intended to
@@ -38,7 +38,7 @@ See the "Measuring Disparity" section for details on implementation.
 }
 \section{Measuring Disparity}{
 
-By default, this function takes the difference in range of \code{\link[=detection_prevalence]{detection_prevalence()}}
+By default, this function takes the difference in range of detection_prevalence
 \code{.estimate}s across groups. That is, the maximum pair-wise disparity between
 groups is the return value of \code{demographic_parity()}'s \code{.estimate}.
 
@@ -51,13 +51,13 @@ diff_range <- function(x, ...) \{diff(range(x$.estimate))\}
 
 demographic_parity_2 <-
   new_groupwise_metric(
-    fn = \code{\link[=detection_prevalence]{detection_prevalence()}},
+    fn = detection_prevalence,
     name = "demographic_parity_2",
     aggregate = diff_range
   )
 }\if{html}{\out{</div>}}
 
-In \code{aggregate()}, \code{x} is the \code{metric_set()} output with \code{\link[=detection_prevalence]{detection_prevalence()}} values
+In \code{aggregate()}, \code{x} is the \code{metric_set()} output with detection_prevalence values
 for each group, and \code{...} gives additional arguments (such as a grouping
 level to refer to as the "baseline") to pass to the function outputted
 by \code{demographic_parity_2()} for context.

--- a/man/equal_opportunity.Rd
+++ b/man/equal_opportunity.Rd
@@ -15,7 +15,7 @@ This function outputs a yardstick \emph{fairness metric} function. Given a
 grouping variable \code{by}, \code{equal_opportunity()} will return a yardstick metric
 function that is associated with the data-variable grouping \code{by} and a
 post-processor. The outputted function will first generate a set
-of \code{\link[=sens]{sens()}} metric values by group before summarizing across
+of sens metric values by group before summarizing across
 groups using the post-processing function.
 
 The outputted function only has a data frame method and is intended to
@@ -35,7 +35,7 @@ See the "Measuring Disparity" section for details on implementation.
 }
 \section{Measuring Disparity}{
 
-By default, this function takes the difference in range of \code{\link[=sens]{sens()}}
+By default, this function takes the difference in range of sens
 \code{.estimate}s across groups. That is, the maximum pair-wise disparity between
 groups is the return value of \code{equal_opportunity()}'s \code{.estimate}.
 
@@ -48,13 +48,13 @@ diff_range <- function(x, ...) \{diff(range(x$.estimate))\}
 
 equal_opportunity_2 <-
   new_groupwise_metric(
-    fn = \code{\link[=sens]{sens()}},
+    fn = sens,
     name = "equal_opportunity_2",
     aggregate = diff_range
   )
 }\if{html}{\out{</div>}}
 
-In \code{aggregate()}, \code{x} is the \code{metric_set()} output with \code{\link[=sens]{sens()}} values
+In \code{aggregate()}, \code{x} is the \code{metric_set()} output with sens values
 for each group, and \code{...} gives additional arguments (such as a grouping
 level to refer to as the "baseline") to pass to the function outputted
 by \code{equal_opportunity_2()} for context.


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/463

@simonpcouch can you verify that this has been fixed?