### PR TITLE
Pretty error on wrongly use of estimate argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ calculated with `roc_auc_survival()`.
 
 * `brier_survival_integrated()` now throws an error if input data only includes 1 evalution time point. (#460)
 
+* Metrics now throw more informative error if `estimate` argument is wrongly used. (#443)
+
 # yardstick 1.2.0
 
 ## New Metrics

--- a/R/template.R
+++ b/R/template.R
@@ -802,6 +802,16 @@ yardstick_eval_select_dots <- function(...,
       return(get_known_selection(expr_label))
     }
   }
+  
+  if ("estimate" %in% names(match.call(expand.dots = FALSE)$...)) {
+    cli::cli_abort(
+      c(
+        x = "This metric doesn't use the {.arg estimate} argument.",
+        i = "Specify the columns without {.code estimate = }."
+      ),
+      call = error_call
+    )
+  }
 
   out <- tidyselect::eval_select(
     expr = expr(c(...)),

--- a/tests/testthat/_snaps/template.md
+++ b/tests/testthat/_snaps/template.md
@@ -90,6 +90,16 @@
       ! Can't subset columns with `TRUE`.
       x `TRUE` must be numeric or character, not `TRUE`.
 
+---
+
+    Code
+      prob_metric_summarizer(name = "roc_auc", fn = roc_auc_vec, data = hpc_f1,
+        truth = obs, estimate = VF:L)
+    Condition
+      Error:
+      x This metric doesn't use the `estimate` argument.
+      i Specify the columns without `estimate = `.
+
 # curve_metric_summarizer()'s errors when wrong things are passes
 
     Code
@@ -120,6 +130,16 @@
       ! Can't subset columns with `TRUE`.
       x `TRUE` must be numeric or character, not `TRUE`.
 
+---
+
+    Code
+      curve_metric_summarizer(name = "roc_curve", fn = roc_curve_vec, data = hpc_f1,
+        truth = obs, estimate = VF:L)
+    Condition
+      Error:
+      x This metric doesn't use the `estimate` argument.
+      i Specify the columns without `estimate = `.
+
 # dynamic_survival_metric_summarizer()'s errors with bad input
 
     Code
@@ -137,6 +157,16 @@
     Condition
       Error:
       ! `estimate` should be a list, not a a <Surv> object.
+
+---
+
+    Code
+      dynamic_survival_metric_summarizer(name = "brier_survival", fn = brier_survival_vec,
+        data = lung_surv, truth = surv_obj, estimate = .pred)
+    Condition
+      Error:
+      x This metric doesn't use the `estimate` argument.
+      i Specify the columns without `estimate = `.
 
 # static_survival_metric_summarizer()'s errors with bad input
 
@@ -194,4 +224,14 @@
     Condition
       Error:
       ! `estimate` should be a list, not a a <Surv> object.
+
+---
+
+    Code
+      curve_survival_metric_summarizer(name = "roc_curve_survival", fn = roc_curve_survival_vec,
+        data = lung_surv, truth = surv_obj, estimate = .pred)
+    Condition
+      Error:
+      x This metric doesn't use the `estimate` argument.
+      i Specify the columns without `estimate = `.
 

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -707,6 +707,17 @@ test_that("prob_metric_summarizer()'s errors when wrong things are passes", {
       obviouslywrong = TRUE
     )
   )
+
+  expect_snapshot(
+    error = TRUE,
+    prob_metric_summarizer(
+      name = "roc_auc",
+      fn = roc_auc_vec,
+      data = hpc_f1,
+      truth = obs,
+      estimate = VF:L
+    )
+  )
 })
 
 test_that("prob_metric_summarizer() deals with characters in truth", {
@@ -970,6 +981,17 @@ test_that("curve_metric_summarizer()'s errors when wrong things are passes", {
       obviouslywrong = TRUE
     )
   )
+
+  expect_snapshot(
+    error = TRUE,
+    curve_metric_summarizer(
+      name = "roc_curve",
+      fn = roc_curve_vec,
+      data = hpc_f1,
+      truth = obs,
+      estimate = VF:L
+    )
+  )
 })
 
 test_that("curve_metric_summarizer() deals with characters in truth", {
@@ -1203,6 +1225,17 @@ test_that("dynamic_survival_metric_summarizer()'s errors with bad input", {
       data = lung_surv,
       truth = surv_obj,
       surv_obj
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    dynamic_survival_metric_summarizer(
+      name = "brier_survival",
+      fn = brier_survival_vec,
+      data = lung_surv,
+      truth = surv_obj,
+      estimate = .pred
     )
   )
 })
@@ -1658,6 +1691,17 @@ test_that("curve_survival_metric_summarizer()'s errors with bad input", {
       data = lung_surv,
       truth = surv_obj,
       surv_obj
+    )
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    curve_survival_metric_summarizer(
+      name = "roc_curve_survival",
+      fn = roc_curve_survival_vec,
+      data = lung_surv,
+      truth = surv_obj,
+      estimate = .pred
     )
   )
 })


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/443

Before:

``` r
library(yardstick)

roc_curve(two_class_example, truth = truth, estimate = Class1)
#> Error in `roc_curve()`:
#> ! Can't rename variables in this context.
```

Now:

``` r
library(yardstick)

roc_curve(two_class_example, truth = truth, estimate = Class1)
#> Error in `roc_curve()`:
#> ✖ This metric doesn't use the `estimate` argument.
#> ℹ Specify the columns without `estimate = `.
```
