### PR TITLE
"it's" -> "its" when applicable in R/ and man/

### DIFF
--- a/R/fair-aaa.R
+++ b/R/fair-aaa.R
@@ -39,7 +39,7 @@
 #'
 #' @return
 #' This function is a
-#' [function factory](https://adv-r.hadley.nz/function-factories.html); it's
+#' [function factory](https://adv-r.hadley.nz/function-factories.html); its
 #' output is itself a function. Further, the functions that this function
 #' outputs are also function factories. More explicitly, this looks like:
 #'

--- a/R/prob-mn_log_loss.R
+++ b/R/prob-mn_log_loss.R
@@ -11,7 +11,7 @@
 #' probabilities of `.6` and `.9` where both are classified as predicting
 #' a positive value, say, `"Yes"`, the accuracy metric would interpret them
 #' as having the same value. If the true output is `"Yes"`, log loss penalizes
-#' `.6` because it is "less sure" of it's result compared to the probability
+#' `.6` because it is "less sure" of its result compared to the probability
 #' of `.9`.
 #'
 #' @family class probability metrics

--- a/man/mn_log_loss.Rd
+++ b/man/mn_log_loss.Rd
@@ -88,7 +88,7 @@ detailed view into the actual performance. For example, given two input
 probabilities of \code{.6} and \code{.9} where both are classified as predicting
 a positive value, say, \code{"Yes"}, the accuracy metric would interpret them
 as having the same value. If the true output is \code{"Yes"}, log loss penalizes
-\code{.6} because it is "less sure" of it's result compared to the probability
+\code{.6} because it is "less sure" of its result compared to the probability
 of \code{.9}.
 }
 \section{Multiclass}{

--- a/man/new_groupwise_metric.Rd
+++ b/man/new_groupwise_metric.Rd
@@ -26,7 +26,7 @@ Examples sections for example uses.}
 }
 \value{
 This function is a
-\href{https://adv-r.hadley.nz/function-factories.html}{function factory}; it's
+\href{https://adv-r.hadley.nz/function-factories.html}{function factory}; its
 output is itself a function. Further, the functions that this function
 outputs are also function factories. More explicitly, this looks like:
 


### PR DESCRIPTION
Few small typos :)
didn't spot any instances of "its" -> "it's"