### PR TITLE
avoid log(0) in poisson_log_loss()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * The ranked probability score for ordinal classification data was added with `ranked_prob_score()`. (#524)
 
+* `poisson_log_loss()` has been enhanced to handle 0 valued estimates, no longer returning `Inf` or `NaN`. (#513)
+
 # yardstick 1.3.2
 
 * All messages, warnings and errors has been translated to use {cli} package (#517, #522).

--- a/R/num-poisson_log_loss.R
+++ b/R/num-poisson_log_loss.R
@@ -75,8 +75,9 @@ poisson_log_loss_impl <- function(truth,
   if (!is.integer(truth)) {
     truth <- as.integer(truth)
   }
-
-  loss <- -stats::dpois(truth, estimate, log = TRUE)
+  eps <- 1e-15
+  estimate <- pmax(estimate, eps)
+  loss <- log(gamma(truth + 1)) + estimate - log(estimate) * truth
 
   yardstick_mean(loss, case_weights = case_weights)
 }

--- a/tests/testthat/test-num-poisson_log_loss.R
+++ b/tests/testthat/test-num-poisson_log_loss.R
@@ -19,6 +19,16 @@ test_that("poisson log-loss", {
   )
 })
 
+test_that("poisson log-loss handles 0 valued estimates (#513)", {
+  count_results <- data_counts()$basic
+
+  count_results$pred <- 0
+
+  expect_false(
+    is.nan(poisson_log_loss(count_results, count, pred)[[".estimate"]]),
+  )
+})
+
 test_that("weighted results are working", {
   count_results <- data_counts()$basic
   count_results$weights <- c(1, 2, 1, 1, 2, 1)

--- a/tests/testthat/test-num-poisson_log_loss.R
+++ b/tests/testthat/test-num-poisson_log_loss.R
@@ -27,6 +27,9 @@ test_that("poisson log-loss handles 0 valued estimates (#513)", {
   expect_false(
     is.nan(poisson_log_loss(count_results, count, pred)[[".estimate"]]),
   )
+  expect_false(
+    is.infinite(poisson_log_loss(count_results, count, pred)[[".estimate"]]),
+  )
 })
 
 test_that("weighted results are working", {
@@ -35,7 +38,7 @@ test_that("weighted results are working", {
 
   expect_identical(
     poisson_log_loss(count_results, count, pred, case_weights = weights)[[".estimate"]],
-    yardstick_mean(-stats::dpois(count_results$count, count_results$pred, log = TRUE), case_weights = count_results$weights)
+    yardstick_mean(log(gamma(count_results$count + 1)) + count_results$pred - log(count_results$pred) * count_results$count, case_weights = count_results$weights)
   )
 })
 


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/513

This approach is alligned with other implementations by using a small `eps` to avoid `log(0)`

- https://pytorch.org/docs/stable/generated/torch.nn.PoissonNLLLoss.html
- https://github.com/yanyachen/MLmetrics/blob/master/R/Count.R#L17

# Before

``` r
yardstick::poisson_log_loss(mtcars, gear, vs)
#> # A tibble: 1 × 3
#>   .metric          .estimator .estimate
#>   <chr>            <chr>          <dbl>
#> 1 poisson_log_loss standard         Inf

yardstick::poisson_log_loss_vec(mtcars$gear, mtcars$vs)
#> [1] Inf
```

# After

``` r
yardstick::poisson_log_loss(mtcars, gear, vs)
#> # A tibble: 1 × 3
#>   .metric          .estimator .estimate
#>   <chr>            <chr>          <dbl>
#> 1 poisson_log_loss standard        72.3

yardstick::poisson_log_loss_vec(mtcars$gear, mtcars$vs)
#> [1] 72.29476
```