### PR TITLE
Ordered metrics in matric sets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `poisson_log_loss()` has been enhanced to handle 0 valued estimates, no longer returning `Inf` or `NaN`. (#513)
 
+* Fixed bug where ranked probability metrics didn't work in combination with other classificiation metrics in `metric_set()`. (#539)
+
 # yardstick 1.3.2
 
 * All messages, warnings and errors has been translated to use {cli} package (#517, #522).

--- a/R/aaa-metrics.R
+++ b/R/aaa-metrics.R
@@ -263,7 +263,9 @@ metric_set <- function(...) {
   # signature of the function is different depending on input functions
   if (fn_cls == "numeric_metric") {
     make_numeric_metric_function(fns)
-  } else if (fn_cls %in% c("prob_metric", "class_metric")) {
+  } else if (
+    fn_cls %in% c("prob_metric", "class_metric", "ordered_prob_metric")
+  ) {
     make_prob_class_metric_function(fns)
   } else if (
     fn_cls %in%
@@ -638,6 +640,7 @@ validate_function_class <- function(fns) {
   valid_cls <- c(
     "class_metric",
     "prob_metric",
+    "ordered_prob_metric",
     "numeric_metric",
     "dynamic_survival_metric",
     "static_survival_metric",
@@ -650,58 +653,21 @@ validate_function_class <- function(fns) {
     }
   }
 
-  # Special case of ONLY class and prob functions together
-  # These are allowed to be together
-  if (n_unique == 2) {
-    if (
-      fn_cls_unique[1] %in%
-        c("class_metric", "prob_metric") &&
-        fn_cls_unique[2] %in% c("class_metric", "prob_metric")
-    ) {
-      return(invisible(fns))
-    }
-
-    if (
-      fn_cls_unique[1] %in%
-        c(
-          "dynamic_survival_metric",
-          "static_survival_metric",
-          "integrated_survival_metric"
-        ) &&
-        fn_cls_unique[2] %in%
-          c(
-            "dynamic_survival_metric",
-            "static_survival_metric",
-            "integrated_survival_metric"
-          )
-    ) {
-      return(invisible(fns))
-    }
+  class_prob_cls <- c("class_metric", "prob_metric", "ordered_prob_metric")
+  if (
+    any(fn_cls_unique %in% class_prob_cls) &&
+      all(fn_cls_unique %in% class_prob_cls)
+  ) {
+    return(invisible(fns))
   }
 
-  if (n_unique == 3) {
-    if (
-      fn_cls_unique[1] %in%
-        c(
-          "dynamic_survival_metric",
-          "static_survival_metric",
-          "integrated_survival_metric"
-        ) &&
-        fn_cls_unique[2] %in%
-          c(
-            "dynamic_survival_metric",
-            "static_survival_metric",
-            "integrated_survival_metric"
-          ) &&
-        fn_cls_unique[3] %in%
-          c(
-            "dynamic_survival_metric",
-            "static_survival_metric",
-            "integrated_survival_metric"
-          )
-    ) {
-      return(invisible(fns))
-    }
+  surv_cls <- c(
+    "dynamic_survival_metric",
+    "static_survival_metric",
+    "integrated_survival_metric"
+  )
+  if (any(fn_cls_unique %in% surv_cls) && all(fn_cls_unique %in% surv_cls)) {
+    return(invisible(fns))
   }
 
   # Special case unevaluated groupwise metric factories

--- a/R/aaa-new.R
+++ b/R/aaa-new.R
@@ -116,6 +116,7 @@ format.metric <- function(x, ...) {
       first_class,
       "prob_metric" = "probability metric",
       "class_metric" = "class metric",
+      "ordered_prob_metric" = "ordered probability metric",
       "numeric_metric" = "numeric metric",
       "dynamic_survival_metric" = "dynamic survival metric",
       "static_survival_metric" = "static survival metric",

--- a/tests/testthat/test-aaa-metrics.R
+++ b/tests/testthat/test-aaa-metrics.R
@@ -143,6 +143,18 @@ test_that("can mix class and class prob metrics together", {
   )
 })
 
+test_that("can mix class and class prob and ordered metrics together", {
+  expect_no_error(
+    mixed_set <- metric_set(kap, roc_auc, ranked_prob_score)
+  )
+
+  hpc_cv$obs <- as.ordered(hpc_cv$obs)
+
+  expect_no_error(
+    mixed_set(hpc_cv, obs, VF:L, estimate = pred)
+  )
+})
+
 test_that("dynamic survival metric sets", {
   skip_if_not_installed("tidyr")
   my_set <- metric_set(brier_survival)


### PR DESCRIPTION
to close https://github.com/tidymodels/yardstick/issues/536

``` r
library(yardstick)
library(dplyr)

data(hpc_cv)

# Making outcome ordered
hpc_cv$obs <- as.ordered(hpc_cv$obs)

cls_mtr <- metric_set(ranked_prob_score, brier_class, kap, roc_auc)
cls_mtr(hpc_cv, obs, VF:L, estimate = pred)
#> # A tibble: 4 × 3
#>   .metric           .estimator .estimate
#>   <chr>             <chr>          <dbl>
#> 1 kap               multiclass    0.508 
#> 2 ranked_prob_score multiclass    0.0857
#> 3 brier_class       multiclass    0.211 
#> 4 roc_auc           hand_till     0.829
```

<sup>Created on 2025-03-11 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>