### PR TITLE
Convert logical inputs to factors

### DIFF
--- a/R/class-accuracy.R
+++ b/R/class-accuracy.R
@@ -94,6 +94,10 @@ accuracy_vec <- function(
   estimate <- as_factor_from_class_pred(estimate)
 
   estimator <- finalize_estimator(truth, metric_class = "accuracy")
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -92,6 +92,11 @@ bal_accuracy_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-detection_prevalence.R
+++ b/R/class-detection_prevalence.R
@@ -93,6 +93,11 @@ detection_prevalence_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -120,6 +120,11 @@ f_meas_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -114,6 +114,11 @@ j_index_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -117,6 +117,10 @@ kap_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "kap")
 
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-mcc.R
+++ b/R/class-mcc.R
@@ -100,6 +100,10 @@ mcc_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
 
   estimator <- finalize_estimator(truth, metric_class = "mcc")
 
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -117,6 +117,11 @@ npv_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -129,6 +129,11 @@ ppv_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -119,6 +119,11 @@ precision_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -119,6 +119,11 @@ recall_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -148,6 +148,11 @@ sens_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -113,6 +113,11 @@ spec_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator)
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -224,6 +224,10 @@ conf_mat_impl <- function(truth, estimate, case_weights, call = caller_env()) {
   estimate <- as_factor_from_class_pred(estimate, call = call)
 
   estimator <- "not binary"
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+    estimate <- factor(estimate)
+  }
   check_class_metric(truth, estimate, case_weights, estimator, call = call)
 
   if (length(levels(truth)) < 2) {

--- a/R/prob-brier_class.R
+++ b/R/prob-brier_class.R
@@ -91,6 +91,9 @@ brier_class_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "brier_class")
 
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -148,6 +148,10 @@ classification_cost_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "classification_cost")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-gain_capture.R
+++ b/R/prob-gain_capture.R
@@ -93,6 +93,10 @@ gain_capture_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator, "gain_capture")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -143,6 +143,10 @@ gain_curve_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "gain_curve")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-mn_log_loss.R
+++ b/R/prob-mn_log_loss.R
@@ -117,6 +117,10 @@ mn_log_loss_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "mn_log_loss")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-pr_auc.R
+++ b/R/prob-pr_auc.R
@@ -90,6 +90,10 @@ pr_auc_vec <- function(
 
   estimator <- finalize_estimator(truth, estimator, "pr_auc")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -99,6 +99,10 @@ pr_curve_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "pr_curve")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -137,6 +137,10 @@ roc_auc_vec <- function(
     case_weights = case_weights
   )
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -127,6 +127,9 @@ roc_aunp_vec <- function(
 
   estimator <- "macro_weighted"
 
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -127,6 +127,9 @@ roc_aunu_vec <- function(
 
   estimator <- "macro"
 
+  if (is.logical(truth)) {
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -106,6 +106,10 @@ roc_curve_vec <- function(
 
   estimator <- finalize_estimator(truth, metric_class = "roc_curve")
 
+  if (is.logical(truth)) {
+    event_level <- "second"  # TRUE is second level of levels(factor(truth))
+    truth <- factor(truth)
+  }
   check_prob_metric(truth, estimate, case_weights, estimator)
 
   if (na_rm) {

--- a/tests/testthat/test-class-bal_accuracy.R
+++ b/tests/testthat/test-class-bal_accuracy.R
@@ -116,3 +116,15 @@ test_that("Two class weighted - sklearn equivalent", {
     py_res$case_weight$binary
   )
 })
+
+
+test_that("logical inputs work", {
+  expect_equal(
+    bal_accuracy_vec(
+      two_class_example$truth == 'Class1',
+      two_class_example$predicted == 'Class1'
+    ) |>
+      round(4),
+    0.8366
+  )
+})

--- a/tests/testthat/test-prob-roc_auc.R
+++ b/tests/testthat/test-prob-roc_auc.R
@@ -532,3 +532,14 @@ test_that("errors with class_pred input", {
     roc_auc_vec(cp_truth, estimate)
   )
 })
+
+test_that("logical inputs work", {
+  expect_equal(
+    roc_auc_vec(
+      two_class_example$truth == 'Class1',
+      two_class_example$Class1
+    ) |>
+      round(4),
+    0.9393
+  )
+})


### PR DESCRIPTION
Instead of logical inputs being errors, for class and prob metrics, logical truth is converted to factor(truth). For class metrics, logical estimate is converted to factor(estimate). For both, when event_level is used, it always set to "second" (TRUE) for logical truth inputs. 

This PR includes the complete working solution, including a commit with tests. All existing and new tests pass.
