### PR TITLE
Add "Supported By Posit" badge to yardstick website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,8 +6,9 @@ template:
   bslib:
     primary: "#CA225E"
   includes:
-      in_header: |
-        <script defer data-domain="yardstick.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
+    in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
+      <script defer data-domain="yardstick.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
 
 development:
   mode: auto
@@ -21,114 +22,114 @@ navbar:
         href: https://www.tidymodels.org/learn/develop/metrics/
 
 reference:
-  - title: Classification Metrics
-    contents:
-    - sens
-    - spec
-    - recall
-    - precision
-    - mcc
-    - j_index
-    - f_meas
-    - accuracy
-    - kap
-    - ppv
-    - npv
-    - bal_accuracy
-    - detection_prevalence
+- title: Classification Metrics
+  contents:
+  - sens
+  - spec
+  - recall
+  - precision
+  - mcc
+  - j_index
+  - f_meas
+  - accuracy
+  - kap
+  - ppv
+  - npv
+  - bal_accuracy
+  - detection_prevalence
 
-  - title: Class Probability Metrics
-    contents:
-    - roc_auc
-    - roc_aunp
-    - roc_aunu
-    - pr_auc
-    - average_precision
-    - gain_capture
-    - mn_log_loss
-    - classification_cost
-    - brier_class
+- title: Class Probability Metrics
+  contents:
+  - roc_auc
+  - roc_aunp
+  - roc_aunu
+  - pr_auc
+  - average_precision
+  - gain_capture
+  - mn_log_loss
+  - classification_cost
+  - brier_class
 
-  - title: Ordered Probability Metrics
-    contents:
-    - ranked_prob_score
+- title: Ordered Probability Metrics
+  contents:
+  - ranked_prob_score
 
-  - title: Regression Metrics
-    contents:
-    - rmse
-    - rsq
-    - rsq_trad
-    - msd
-    - mae
-    - mpe
-    - mape
-    - smape
-    - mase
-    - ccc
-    - rpiq
-    - rpd
-    - huber_loss
-    - huber_loss_pseudo
-    - iic
-    - poisson_log_loss
+- title: Regression Metrics
+  contents:
+  - rmse
+  - rsq
+  - rsq_trad
+  - msd
+  - mae
+  - mpe
+  - mape
+  - smape
+  - mase
+  - ccc
+  - rpiq
+  - rpd
+  - huber_loss
+  - huber_loss_pseudo
+  - iic
+  - poisson_log_loss
 
-  - title: Fairness Metrics
-    contents:
-    - new_groupwise_metric
-    - demographic_parity
-    - equalized_odds
-    - equal_opportunity
+- title: Fairness Metrics
+  contents:
+  - new_groupwise_metric
+  - demographic_parity
+  - equalized_odds
+  - equal_opportunity
 
-  - title: Dynamic Survival Metrics
-    contents:
-    - brier_survival
-    - brier_survival_integrated
-    - roc_auc_survival
+- title: Dynamic Survival Metrics
+  contents:
+  - brier_survival
+  - brier_survival_integrated
+  - roc_auc_survival
 
-  - title: Static Survival Metrics
-    contents:
-    - concordance_survival
+- title: Static Survival Metrics
+  contents:
+  - concordance_survival
 
-  - title: Curve Survival Functions
-    contents:
-    - roc_curve_survival
+- title: Curve Survival Functions
+  contents:
+  - roc_curve_survival
 
-  - title: Curve Functions
-    contents:
-    - roc_curve
-    - pr_curve
-    - gain_curve
-    - lift_curve
+- title: Curve Functions
+  contents:
+  - roc_curve
+  - pr_curve
+  - gain_curve
+  - lift_curve
 
-  - title: Other Functions
-    contents:
-    - metrics
-    - metric_set
-    - metric_tweak
-    - conf_mat
-    - summary.conf_mat
-    - matches("tidy")
+- title: Other Functions
+  contents:
+  - metrics
+  - metric_set
+  - metric_tweak
+  - conf_mat
+  - summary.conf_mat
+  - matches("tidy")
 
-  - title: Development Functions
-    contents:
-    - class_metric_summarizer
-    - numeric_metric_summarizer
-    - prob_metric_summarizer
-    - curve_metric_summarizer
-    - check_numeric_metric
-    - check_class_metric
-    - check_prob_metric
-    - check_dynamic_survival_metric
-    - yardstick_remove_missing
-    - yardstick_any_missing
-    - get_weights
-    - new-metric
+- title: Development Functions
+  contents:
+  - class_metric_summarizer
+  - numeric_metric_summarizer
+  - prob_metric_summarizer
+  - curve_metric_summarizer
+  - check_numeric_metric
+  - check_class_metric
+  - check_prob_metric
+  - check_dynamic_survival_metric
+  - yardstick_remove_missing
+  - yardstick_any_missing
+  - get_weights
+  - new-metric
 
-  - title: Data Sets
-    contents:
-    - hpc_cv
-    - lung_surv
-    - pathology
-    - solubility_test
-    - two_class_example
+- title: Data Sets
+  contents:
+  - hpc_cv
+  - lung_surv
+  - pathology
+  - solubility_test
+  - two_class_example
 


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the yardstick website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of yardstick website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/yardstick-1200.png)

At 992px browser width:

![Screenshot of yardstick website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/yardstick-992.png)

At 991px browser width:

![Screenshot of yardstick website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/yardstick-991.png)

