### PR TITLE
check na_rm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Added quantile metric `weighted_interval_score()`. (#569)
 
+* Added checks to all metrics for `na_rm` argument. (#349)
+
 # yardstick 1.3.2
 
 * All messages, warnings and errors has been translated to use {cli} package (#517, #522).

--- a/R/class-accuracy.R
+++ b/R/class-accuracy.R
@@ -90,6 +90,7 @@ accuracy_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-bal_accuracy.R
+++ b/R/class-bal_accuracy.R
@@ -87,6 +87,7 @@ bal_accuracy_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-detection_prevalence.R
+++ b/R/class-detection_prevalence.R
@@ -88,6 +88,7 @@ detection_prevalence_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-f_meas.R
+++ b/R/class-f_meas.R
@@ -115,6 +115,7 @@ f_meas_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-j_index.R
+++ b/R/class-j_index.R
@@ -109,6 +109,7 @@ j_index_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-kap.R
+++ b/R/class-kap.R
@@ -112,6 +112,7 @@ kap_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-mcc.R
+++ b/R/class-mcc.R
@@ -95,6 +95,7 @@ mcc.matrix <- function(data, ...) {
 #' @export
 #' @rdname mcc
 mcc_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-npv.R
+++ b/R/class-npv.R
@@ -112,6 +112,7 @@ npv_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-ppv.R
+++ b/R/class-ppv.R
@@ -124,6 +124,7 @@ ppv_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-precision.R
+++ b/R/class-precision.R
@@ -114,6 +114,7 @@ precision_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-recall.R
+++ b/R/class-recall.R
@@ -114,6 +114,7 @@ recall_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-sens.R
+++ b/R/class-sens.R
@@ -143,6 +143,7 @@ sens_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/class-spec.R
+++ b/R/class-spec.R
@@ -108,6 +108,7 @@ spec_vec <- function(
   event_level = yardstick_event_level(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
   estimate <- as_factor_from_class_pred(estimate)
 

--- a/R/num-ccc.R
+++ b/R/num-ccc.R
@@ -76,6 +76,7 @@ ccc_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-huber_loss.R
+++ b/R/num-huber_loss.R
@@ -66,6 +66,7 @@ huber_loss_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-iic.R
+++ b/R/num-iic.R
@@ -68,6 +68,7 @@ iic.data.frame <- function(
 #' @export
 #' @rdname iic
 iic_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-mae.R
+++ b/R/num-mae.R
@@ -47,6 +47,7 @@ mae.data.frame <- function(
 #' @export
 #' @rdname mae
 mae_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-mape.R
+++ b/R/num-mape.R
@@ -51,6 +51,7 @@ mape.data.frame <- function(
 #' @export
 #' @rdname mape
 mape_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-mase.R
+++ b/R/num-mase.R
@@ -91,6 +91,7 @@ mase_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-mpe.R
+++ b/R/num-mpe.R
@@ -90,6 +90,7 @@ mpe.data.frame <- function(
 #' @export
 #' @rdname mpe
 mpe_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-msd.R
+++ b/R/num-msd.R
@@ -61,6 +61,7 @@ msd.data.frame <- function(
 #' @export
 #' @rdname msd
 msd_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-poisson_log_loss.R
+++ b/R/num-poisson_log_loss.R
@@ -58,6 +58,7 @@ poisson_log_loss_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-pseudo_huber_loss.R
+++ b/R/num-pseudo_huber_loss.R
@@ -65,6 +65,7 @@ huber_loss_pseudo_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-rmse.R
+++ b/R/num-rmse.R
@@ -70,6 +70,7 @@ rmse.data.frame <- function(
 #' @export
 #' @rdname rmse
 rmse_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-rpd.R
+++ b/R/num-rpd.R
@@ -79,6 +79,7 @@ rpd.data.frame <- function(
 #' @export
 #' @rdname rpd
 rpd_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-rpiq.R
+++ b/R/num-rpiq.R
@@ -57,6 +57,7 @@ rpiq.data.frame <- function(
 #' @export
 #' @rdname rpiq
 rpiq_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-rsq.R
+++ b/R/num-rsq.R
@@ -81,6 +81,7 @@ rsq.data.frame <- function(
 #' @export
 #' @rdname rsq
 rsq_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-rsq_trad.R
+++ b/R/num-rsq_trad.R
@@ -75,6 +75,7 @@ rsq_trad_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/num-smape.R
+++ b/R/num-smape.R
@@ -51,6 +51,7 @@ smape.data.frame <- function(
 #' @export
 #' @rdname smape
 smape_vec <- function(truth, estimate, na_rm = TRUE, case_weights = NULL, ...) {
+  check_bool(na_rm)
   check_numeric_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/orderedprob-ranked_prob_score.R
+++ b/R/orderedprob-ranked_prob_score.R
@@ -102,6 +102,7 @@ ranked_prob_score_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "ranked_prob_score")

--- a/R/prob-average_precision.R
+++ b/R/prob-average_precision.R
@@ -92,6 +92,7 @@ average_precision_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "average_precision")

--- a/R/prob-brier_class.R
+++ b/R/prob-brier_class.R
@@ -87,6 +87,7 @@ brier_class_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "brier_class")

--- a/R/prob-classification_cost.R
+++ b/R/prob-classification_cost.R
@@ -144,6 +144,7 @@ classification_cost_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "classification_cost")

--- a/R/prob-gain_capture.R
+++ b/R/prob-gain_capture.R
@@ -89,6 +89,7 @@ gain_capture_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "gain_capture")

--- a/R/prob-gain_curve.R
+++ b/R/prob-gain_curve.R
@@ -139,6 +139,7 @@ gain_curve_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "gain_curve")

--- a/R/prob-lift_curve.R
+++ b/R/prob-lift_curve.R
@@ -122,6 +122,7 @@ lift_curve_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   # Doesn't validate inputs here since it is done in gain_curve_vec()
 
   # tibble result, possibly grouped

--- a/R/prob-mn_log_loss.R
+++ b/R/prob-mn_log_loss.R
@@ -113,6 +113,7 @@ mn_log_loss_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "mn_log_loss")

--- a/R/prob-pr_auc.R
+++ b/R/prob-pr_auc.R
@@ -86,6 +86,7 @@ pr_auc_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, estimator, "pr_auc")

--- a/R/prob-pr_curve.R
+++ b/R/prob-pr_curve.R
@@ -95,6 +95,7 @@ pr_curve_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "pr_curve")

--- a/R/prob-roc_auc.R
+++ b/R/prob-roc_auc.R
@@ -126,6 +126,7 @@ roc_auc_vec <- function(
   options = list(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_auc_vec", options)

--- a/R/prob-roc_aunp.R
+++ b/R/prob-roc_aunp.R
@@ -121,6 +121,7 @@ roc_aunp_vec <- function(
   options = list(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_aunp_vec", options)

--- a/R/prob-roc_aunu.R
+++ b/R/prob-roc_aunu.R
@@ -121,6 +121,7 @@ roc_aunu_vec <- function(
   options = list(),
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   check_roc_options_deprecated("roc_aunu_vec", options)

--- a/R/prob-roc_curve.R
+++ b/R/prob-roc_curve.R
@@ -102,6 +102,7 @@ roc_curve_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   abort_if_class_pred(truth)
 
   estimator <- finalize_estimator(truth, metric_class = "roc_curve")

--- a/R/quant-weighted_interval_score.R
+++ b/R/quant-weighted_interval_score.R
@@ -145,6 +145,7 @@ weighted_interval_score_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_quantile_metric(truth, estimate, case_weights)
 
   estimate_quantile_levels <- hardhat::extract_quantile_levels(estimate)

--- a/R/surv-brier_survival.R
+++ b/R/surv-brier_survival.R
@@ -108,6 +108,7 @@ brier_survival_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_dynamic_survival_metric(
     truth,
     estimate,

--- a/R/surv-brier_survival_integrated.R
+++ b/R/surv-brier_survival_integrated.R
@@ -90,6 +90,7 @@ brier_survival_integrated_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_dynamic_survival_metric(
     truth,
     estimate,

--- a/R/surv-concordance_survival.R
+++ b/R/surv-concordance_survival.R
@@ -89,6 +89,7 @@ concordance_survival_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_static_survival_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/R/surv-roc_curve_survival.R
+++ b/R/surv-roc_curve_survival.R
@@ -110,6 +110,7 @@ roc_curve_survival_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_dynamic_survival_metric(
     truth,
     estimate,

--- a/R/surv-royston.R
+++ b/R/surv-royston.R
@@ -76,6 +76,7 @@ royston_survival_vec <- function(
   case_weights = NULL,
   ...
 ) {
+  check_bool(na_rm)
   check_linear_pred_survival_metric(truth, estimate, case_weights)
 
   if (na_rm) {

--- a/tests/testthat/_snaps/class-accuracy.md
+++ b/tests/testthat/_snaps/class-accuracy.md
@@ -6,3 +6,11 @@
       Error in `accuracy_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      accuracy_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `accuracy_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-bal_accuracy.md
+++ b/tests/testthat/_snaps/class-bal_accuracy.md
@@ -6,3 +6,11 @@
       Error in `bal_accuracy_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      bal_accuracy_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `bal_accuracy_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-detection_prevalence.md
+++ b/tests/testthat/_snaps/class-detection_prevalence.md
@@ -6,3 +6,11 @@
       Error in `detection_prevalence_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      detection_prevalence(1, 1, na_rm = "yes")
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'detection_prevalence' applied to an object of class "c('double', 'numeric')"
+

--- a/tests/testthat/_snaps/class-f_meas.md
+++ b/tests/testthat/_snaps/class-f_meas.md
@@ -82,3 +82,11 @@
       Error in `f_meas_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      f_meas_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `f_meas_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-j_index.md
+++ b/tests/testthat/_snaps/class-j_index.md
@@ -53,3 +53,11 @@
       Error in `j_index_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      j_index_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `j_index_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-kap.md
+++ b/tests/testthat/_snaps/class-kap.md
@@ -22,3 +22,11 @@
       Error in `kap_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      kap_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `kap_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-mcc.md
+++ b/tests/testthat/_snaps/class-mcc.md
@@ -6,3 +6,11 @@
       Error in `mcc_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      mcc_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mcc_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-npv.md
+++ b/tests/testthat/_snaps/class-npv.md
@@ -6,3 +6,11 @@
       Error in `accuracy_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      npv_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `npv_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-ppv.md
+++ b/tests/testthat/_snaps/class-ppv.md
@@ -16,3 +16,11 @@
       Error in `ppv_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      ppv_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `ppv_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-precision.md
+++ b/tests/testthat/_snaps/class-precision.md
@@ -38,3 +38,11 @@
       Error in `precision_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      precision_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `precision_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-recall.md
+++ b/tests/testthat/_snaps/class-recall.md
@@ -27,3 +27,11 @@
       Error in `recall_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      recall_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `recall_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-sens.md
+++ b/tests/testthat/_snaps/class-sens.md
@@ -27,3 +27,11 @@
       Error in `sensitivity_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      sensitivity_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `sensitivity_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/class-spec.md
+++ b/tests/testthat/_snaps/class-spec.md
@@ -27,3 +27,11 @@
       Error in `specificity_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      specificity_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `specificity_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-ccc.md
+++ b/tests/testthat/_snaps/num-ccc.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      ccc_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `ccc_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-huber_loss.md
+++ b/tests/testthat/_snaps/num-huber_loss.md
@@ -14,3 +14,11 @@
       Error in `huber_loss()`:
       ! `delta` must be a number, not a double vector.
 
+# na_rm argument check
+
+    Code
+      huber_loss_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `huber_loss_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-iic.md
+++ b/tests/testthat/_snaps/num-iic.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      iic_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `iic_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-mae.md
+++ b/tests/testthat/_snaps/num-mae.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      mae_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mae_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-mape.md
+++ b/tests/testthat/_snaps/num-mape.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      mape_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mape_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-mase.md
+++ b/tests/testthat/_snaps/num-mase.md
@@ -46,3 +46,11 @@
       Error in `mase()`:
       ! `truth` (32) must have a length greater than `m` (100) to compute the out-of-sample naive mean absolute error.
 
+# na_rm argument check
+
+    Code
+      mase_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mase_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-mpe.md
+++ b/tests/testthat/_snaps/num-mpe.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      mpe_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mpe_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-msd.md
+++ b/tests/testthat/_snaps/num-msd.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      msd_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `msd_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-poisson_log_loss.md
+++ b/tests/testthat/_snaps/num-poisson_log_loss.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      poisson_log_loss_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `poisson_log_loss_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-pseudo_huber_loss.md
+++ b/tests/testthat/_snaps/num-pseudo_huber_loss.md
@@ -14,3 +14,11 @@
       Error in `huber_loss_pseudo()`:
       ! `delta` must be a number, not a double vector.
 
+# na_rm argument check
+
+    Code
+      huber_loss_pseudo_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `huber_loss_pseudo_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-rmse.md
+++ b/tests/testthat/_snaps/num-rmse.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      rmse_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `rmse_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-rpd.md
+++ b/tests/testthat/_snaps/num-rpd.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      rpd_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `rpd_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-rpiq.md
+++ b/tests/testthat/_snaps/num-rpiq.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      rpiq_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `rpiq_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-rsq.md
+++ b/tests/testthat/_snaps/num-rsq.md
@@ -38,3 +38,11 @@
       Warning:
       A correlation computation is required, but `truth` is constant and has 0 standard deviation, resulting in a divide by 0 error. `NA` will be returned.
 
+# na_rm argument check
+
+    Code
+      rsq_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `rsq_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-rsq_trad.md
+++ b/tests/testthat/_snaps/num-rsq_trad.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      rsq_trad_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `rsq_trad_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/num-smape.md
+++ b/tests/testthat/_snaps/num-smape.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      smape_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `smape_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/orderedprob-ranked_prob_score.md
+++ b/tests/testthat/_snaps/orderedprob-ranked_prob_score.md
@@ -22,3 +22,11 @@
       Error in `ranked_prob_score_vec()`:
       ! The number of levels in `truth` (2) must match the number of columns supplied in `...` (1).
 
+# na_rm argument check
+
+    Code
+      ranked_prob_score_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `ranked_prob_score_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-average_precision.md
+++ b/tests/testthat/_snaps/prob-average_precision.md
@@ -30,3 +30,11 @@
       Error in `average_precision_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      average_precision_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `average_precision_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-brier_class.md
+++ b/tests/testthat/_snaps/prob-brier_class.md
@@ -6,3 +6,11 @@
       Error in `brier_class_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      brier_class_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `brier_class_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-classification_cost.md
+++ b/tests/testthat/_snaps/prob-classification_cost.md
@@ -86,3 +86,11 @@
       Error in `classification_cost_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      classification_cost_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `classification_cost_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-gain_capture.md
+++ b/tests/testthat/_snaps/prob-gain_capture.md
@@ -6,3 +6,11 @@
       Error in `gain_capture_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      gain_capture_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `gain_capture_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-gain_curve.md
+++ b/tests/testthat/_snaps/prob-gain_curve.md
@@ -23,3 +23,11 @@
       Error in `gain_curve_vec_vec()`:
       ! could not find function "gain_curve_vec_vec"
 
+# na_rm argument check
+
+    Code
+      gain_curve_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `gain_curve_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-lift_curve.md
+++ b/tests/testthat/_snaps/prob-lift_curve.md
@@ -14,3 +14,11 @@
       Error in `gain_curve_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      lift_curve_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `lift_curve_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-mn_log_loss.md
+++ b/tests/testthat/_snaps/prob-mn_log_loss.md
@@ -6,3 +6,11 @@
       Error in `mn_log_loss_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      mn_log_loss_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `mn_log_loss_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-pr_auc.md
+++ b/tests/testthat/_snaps/prob-pr_auc.md
@@ -6,3 +6,11 @@
       Error in `pr_auc_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      pr_auc_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `pr_auc_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-pr_curve.md
+++ b/tests/testthat/_snaps/prob-pr_curve.md
@@ -23,3 +23,11 @@
       x Missing values were detected and `na_ra = FALSE`.
       i Not able to perform calculations.
 
+# na_rm argument check
+
+    Code
+      pr_curve_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `pr_curve_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-roc_auc.md
+++ b/tests/testthat/_snaps/prob-roc_auc.md
@@ -120,3 +120,11 @@
       Error in `roc_auc_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      roc_auc_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `roc_auc_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-roc_aunp.md
+++ b/tests/testthat/_snaps/prob-roc_aunp.md
@@ -33,3 +33,11 @@
       Error in `roc_aunp_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      roc_aunp_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `roc_aunp_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-roc_aunu.md
+++ b/tests/testthat/_snaps/prob-roc_aunu.md
@@ -33,3 +33,11 @@
       Error in `roc_aunu_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      roc_aunu_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `roc_aunu_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/prob-roc_curve.md
+++ b/tests/testthat/_snaps/prob-roc_curve.md
@@ -40,3 +40,11 @@
       Error in `roc_curve_vec()`:
       ! `truth` should not a <class_pred> object.
 
+# na_rm argument check
+
+    Code
+      roc_curve_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `roc_curve_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/quant-weighted_interval_score.md
+++ b/tests/testthat/_snaps/quant-weighted_interval_score.md
@@ -7,3 +7,11 @@
       Error in `weighted_interval_score_vec()`:
       ! When `quantile_levels` is not a subset of those available in `estimate`, `quantile_estimate_nas` may not be `'drop'`.
 
+# na_rm argument check
+
+    Code
+      weighted_interval_score_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `weighted_interval_score_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/surv-brier_survival.md
+++ b/tests/testthat/_snaps/surv-brier_survival.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      brier_survival_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `brier_survival_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/surv-brier_survival_integrated.md
+++ b/tests/testthat/_snaps/surv-brier_survival_integrated.md
@@ -6,3 +6,11 @@
       Error in `brier_survival_integrated()`:
       ! At least 2 evaluation times are required. Only 1 unique time was given.
 
+# na_rm argument check
+
+    Code
+      brier_survival_integrated_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `brier_survival_integrated_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/surv-concordance_survival.md
+++ b/tests/testthat/_snaps/surv-concordance_survival.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      concordance_survival_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `concordance_survival_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/surv-roc_curve_survival.md
+++ b/tests/testthat/_snaps/surv-roc_curve_survival.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      roc_auc_survival_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `roc_curve_survival_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/_snaps/surv-royston.md
+++ b/tests/testthat/_snaps/surv-royston.md
@@ -1,0 +1,8 @@
+# na_rm argument check
+
+    Code
+      royston_survival_vec(1, 1, na_rm = "yes")
+    Condition
+      Error in `royston_survival_vec()`:
+      ! `na_rm` must be `TRUE` or `FALSE`, not the string "yes".
+

--- a/tests/testthat/test-class-accuracy.R
+++ b/tests/testthat/test-class-accuracy.R
@@ -120,3 +120,10 @@ test_that("Multi class - sklearn equivalent", {
     py_res$multiclass
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    accuracy_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-bal_accuracy.R
+++ b/tests/testthat/test-class-bal_accuracy.R
@@ -116,3 +116,10 @@ test_that("Two class weighted - sklearn equivalent", {
     py_res$case_weight$binary
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    bal_accuracy_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-detection_prevalence.R
+++ b/tests/testthat/test-class-detection_prevalence.R
@@ -118,3 +118,10 @@ test_that("work with class_pred input", {
     detection_prevalence_vec(cp_truth, cp_estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    detection_prevalence(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-f_meas.R
+++ b/tests/testthat/test-class-f_meas.R
@@ -295,3 +295,10 @@ test_that("Multi class weighted - sklearn equivalent", {
     py_res_.5$case_weight$weighted
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    f_meas_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-j_index.R
+++ b/tests/testthat/test-class-j_index.R
@@ -170,3 +170,10 @@ test_that("work with class_pred input", {
     j_index_vec(cp_truth, cp_estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    j_index_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-kap.R
+++ b/tests/testthat/test-class-kap.R
@@ -240,3 +240,10 @@ test_that("quadratic weighting case weighted - sklearn equivalent", {
     py_res$case_weight$quadratic_multiclass
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    kap_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-mcc.R
+++ b/tests/testthat/test-class-mcc.R
@@ -132,3 +132,10 @@ test_that("Multi class case weighted - sklearn equivalent", {
     py_res$case_weight$multiclass
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mcc_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-npv.R
+++ b/tests/testthat/test-class-npv.R
@@ -149,3 +149,10 @@ test_that("Multi class weighted - sklearn equivalent", {
     py_res$case_weight$macro
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    npv_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-ppv.R
+++ b/tests/testthat/test-class-ppv.R
@@ -170,3 +170,10 @@ test_that("work with class_pred input", {
     ppv_vec(cp_truth, cp_estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    ppv_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-precision.R
+++ b/tests/testthat/test-class-precision.R
@@ -190,3 +190,10 @@ test_that("Multi class case weighted - sklearn equivalent", {
     py_res$case_weight$weighted
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    precision_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-recall.R
+++ b/tests/testthat/test-class-recall.R
@@ -178,3 +178,10 @@ test_that("Multi class case weighted - sklearn equivalent", {
     py_res$case_weight$weighted
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    recall_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-sens.R
+++ b/tests/testthat/test-class-sens.R
@@ -245,3 +245,10 @@ test_that("work with class_pred input", {
     sensitivity_vec(cp_truth, cp_estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    sensitivity_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-class-spec.R
+++ b/tests/testthat/test-class-spec.R
@@ -178,3 +178,10 @@ test_that("work with class_pred input", {
     specificity_vec(cp_truth, cp_estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    specificity_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-ccc.R
+++ b/tests/testthat/test-num-ccc.R
@@ -125,3 +125,10 @@ test_that("works with hardhat case weights", {
     ccc_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    ccc_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-huber_loss.R
+++ b/tests/testthat/test-num-huber_loss.R
@@ -65,3 +65,10 @@ test_that("works with hardhat case weights", {
     huber_loss_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    huber_loss_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-iic.R
+++ b/tests/testthat/test-num-iic.R
@@ -54,3 +54,10 @@ test_that("works with hardhat case weights", {
     iic_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    iic_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-mae.R
+++ b/tests/testthat/test-num-mae.R
@@ -38,3 +38,10 @@ test_that("works with hardhat case weights", {
     mae_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mae_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-mape.R
+++ b/tests/testthat/test-num-mape.R
@@ -61,3 +61,10 @@ test_that("works with hardhat case weights", {
     mape_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mape_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-mase.R
+++ b/tests/testthat/test-num-mase.R
@@ -98,3 +98,10 @@ test_that("mase() errors if m is larger than number of observations", {
     mase(mtcars, mpg, disp, m = 100)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mase_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-mpe.R
+++ b/tests/testthat/test-num-mpe.R
@@ -60,3 +60,10 @@ test_that("works with hardhat case weights", {
     mpe_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mpe_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-msd.R
+++ b/tests/testthat/test-num-msd.R
@@ -52,3 +52,10 @@ test_that("works with hardhat case weights", {
     msd_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    msd_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-poisson_log_loss.R
+++ b/tests/testthat/test-num-poisson_log_loss.R
@@ -68,3 +68,10 @@ test_that("works with hardhat case weights", {
     poisson_log_loss_vec(df$count, df$pred, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    poisson_log_loss_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-pseudo_huber_loss.R
+++ b/tests/testthat/test-num-pseudo_huber_loss.R
@@ -67,3 +67,10 @@ test_that("works with hardhat case weights", {
     huber_loss_pseudo_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    huber_loss_pseudo_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-rmse.R
+++ b/tests/testthat/test-num-rmse.R
@@ -48,3 +48,10 @@ test_that("works with hardhat case weights", {
     rmse_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    rmse_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-rpd.R
+++ b/tests/testthat/test-num-rpd.R
@@ -50,3 +50,10 @@ test_that("works with hardhat case weights", {
     rpd_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    rpd_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-rpiq.R
+++ b/tests/testthat/test-num-rpiq.R
@@ -42,3 +42,10 @@ test_that("works with hardhat case weights", {
     rpiq_vec(df$count, df$pred, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    rpiq_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-rsq.R
+++ b/tests/testthat/test-num-rsq.R
@@ -81,3 +81,10 @@ test_that("works with hardhat case weights", {
     rsq_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    rsq_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-rsq_trad.R
+++ b/tests/testthat/test-num-rsq_trad.R
@@ -54,3 +54,10 @@ test_that("works with hardhat case weights", {
     rsq_trad_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    rsq_trad_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-num-smape.R
+++ b/tests/testthat/test-num-smape.R
@@ -50,3 +50,10 @@ test_that("works with hardhat case weights", {
     smape_vec(df$solubility, df$prediction, case_weights = freq_wgt)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    smape_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-orderedprob-ranked_prob_score.R
+++ b/tests/testthat/test-orderedprob-ranked_prob_score.R
@@ -94,3 +94,10 @@ test_that("errors with bad input", {
     ranked_prob_score_vec(ord_truth, estimate_1D)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    ranked_prob_score_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-average_precision.R
+++ b/tests/testthat/test-prob-average_precision.R
@@ -137,3 +137,10 @@ test_that("errors with class_pred input", {
     average_precision_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    average_precision_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-brier_class.R
+++ b/tests/testthat/test-prob-brier_class.R
@@ -101,3 +101,10 @@ test_that("errors with class_pred input", {
     brier_class_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    brier_class_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-classification_cost.R
+++ b/tests/testthat/test-prob-classification_cost.R
@@ -525,3 +525,10 @@ test_that("errors with class_pred input", {
     classification_cost_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    classification_cost_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-gain_capture.R
+++ b/tests/testthat/test-prob-gain_capture.R
@@ -184,3 +184,10 @@ test_that("errors with class_pred input", {
     gain_capture_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    gain_capture_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-gain_curve.R
+++ b/tests/testthat/test-prob-gain_curve.R
@@ -281,3 +281,10 @@ test_that("errors with class_pred input", {
     gain_curve_vec_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    gain_curve_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-lift_curve.R
+++ b/tests/testthat/test-prob-lift_curve.R
@@ -208,3 +208,10 @@ test_that("errors with class_pred input", {
     lift_curve_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    lift_curve_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-mn_log_loss.R
+++ b/tests/testthat/test-prob-mn_log_loss.R
@@ -189,3 +189,10 @@ test_that("Multi class case weighted - sklearn equivalent", {
     py_res$case_weight$multiclass_sum
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    mn_log_loss_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-pr_auc.R
+++ b/tests/testthat/test-prob-pr_auc.R
@@ -114,3 +114,10 @@ test_that("errors with class_pred input", {
     pr_auc_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    pr_auc_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-pr_curve.R
+++ b/tests/testthat/test-prob-pr_curve.R
@@ -269,3 +269,10 @@ test_that("na_rm = FALSE errors if missing values are present", {
     pr_curve_vec(df$truth, df$Class1, na_rm = FALSE)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    pr_curve_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-roc_auc.R
+++ b/tests/testthat/test-prob-roc_auc.R
@@ -532,3 +532,10 @@ test_that("errors with class_pred input", {
     roc_auc_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    roc_auc_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-roc_aunp.R
+++ b/tests/testthat/test-prob-roc_aunp.R
@@ -115,3 +115,10 @@ test_that("work with class_pred input", {
     roc_aunp_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    roc_aunp_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-roc_aunu.R
+++ b/tests/testthat/test-prob-roc_aunu.R
@@ -111,3 +111,10 @@ test_that("errors with class_pred input", {
     roc_aunu_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    roc_aunu_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-prob-roc_curve.R
+++ b/tests/testthat/test-prob-roc_curve.R
@@ -191,3 +191,10 @@ test_that("errors with class_pred input", {
     roc_curve_vec(cp_truth, estimate)
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    roc_curve_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-quant-weighted_interval_score.R
+++ b/tests/testthat/test-quant-weighted_interval_score.R
@@ -84,3 +84,10 @@ test_that("Missing value behaviours works", {
     NA_real_
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    weighted_interval_score_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-surv-brier_survival.R
+++ b/tests/testthat/test-surv-brier_survival.R
@@ -83,3 +83,10 @@ test_that("riskRegression equivalent", {
     yardstick_res$.estimate
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    brier_survival_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-surv-brier_survival_integrated.R
+++ b/tests/testthat/test-surv-brier_survival_integrated.R
@@ -99,3 +99,10 @@ test_that("works with hardhat case weights", {
     )
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    brier_survival_integrated_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-surv-concordance_survival.R
+++ b/tests/testthat/test-surv-concordance_survival.R
@@ -96,3 +96,10 @@ test_that("works with hardhat case weights", {
     )
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    concordance_survival_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-surv-roc_curve_survival.R
+++ b/tests/testthat/test-surv-roc_curve_survival.R
@@ -224,3 +224,10 @@ test_that("hand calculated equivalent", {
     exp_spec
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    roc_auc_survival_vec(1, 1, na_rm = "yes")
+  )
+})

--- a/tests/testthat/test-surv-royston.R
+++ b/tests/testthat/test-surv-royston.R
@@ -102,3 +102,10 @@ test_that("works with hardhat case weights", {
     )
   )
 })
+
+test_that("na_rm argument check", {
+  expect_snapshot(
+    error = TRUE,
+    royston_survival_vec(1, 1, na_rm = "yes")
+  )
+})


### PR DESCRIPTION
To close #349 

``` r
yardstick::rmse_vec(c(1, 3, NA), c(2, 5, 2), na_rm = 3)
#> Error in `yardstick::rmse_vec()`:
#> ! `na_rm` must be `TRUE` or `FALSE`, not the number 3.
yardstick::rmse_vec(c(1, 3, 1), c(2, 5, 2), na_rm = "x")
#> Error in `yardstick::rmse_vec()`:
#> ! `na_rm` must be `TRUE` or `FALSE`, not the string "x".
yardstick::rmse_vec(c(1, 3, NA), c(2, 5, 2), na_rm = c(TRUE, FALSE))
#> Error in `yardstick::rmse_vec()`:
#> ! `na_rm` must be `TRUE` or `FALSE`, not a logical vector.
```

<sup>Created on 2026-01-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>