### PR TITLE
add example of modifying `autoplot.conf_mat()` method

### DIFF
--- a/R/conf_mat.R
+++ b/R/conf_mat.R
@@ -85,6 +85,10 @@
 #'
 #' autoplot(cm, type = "mosaic")
 #' autoplot(cm, type = "heatmap")
+#'
+#' # And can be modified further like normal ggplot2 objects
+#' autoplot(cm, type = "heatmap") +
+#'   geom_label(aes(label = Freq), fill = "white")
 #' @export
 conf_mat <- function(data, ...) {
   UseMethod("conf_mat")

--- a/man/conf_mat.Rd
+++ b/man/conf_mat.Rd
@@ -119,6 +119,10 @@ library(ggplot2)
 
 autoplot(cm, type = "mosaic")
 autoplot(cm, type = "heatmap")
+
+# And can be modified further like normal ggplot2 objects
+autoplot(cm, type = "heatmap") +
+  geom_label(aes(label = Freq), fill = "white")
 \dontshow{\}) # examplesIf}
 }
 \seealso{


### PR DESCRIPTION
To close https://github.com/tidymodels/yardstick/issues/437

I decided that the better choice here would be to document that we can modify the conf mat after the fact

``` r
library(yardstick)
library(ggplot2)

two_class_example |>
  conf_mat(truth, predicted) |>
  autoplot(type = "heatmap") +
  geom_label(aes(label = Freq), fill = "white")
```

![](https://i.imgur.com/Dmv32CL.png)<!-- -->

<sup>Created on 2026-01-22 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>