### PR TITLE
avoid too large case weights in brier_class()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * The ranked probability score for ordinal classification data was added with `ranked_prob_score()`. (#524)
 
+* Fixed bug where `brier_class()` returns NaN with extreme value case weights. (#614)
+
 * `poisson_log_loss()` has been enhanced to handle 0 valued estimates, no longer returning `Inf` or `NaN`. (#513)
 
 * Fixed bug where ranked probability metrics didn't work in combination with other classification metrics in `metric_set()`. (#539)

--- a/R/prob-brier_class.R
+++ b/R/prob-brier_class.R
@@ -160,6 +160,11 @@ brier_ind <- function(truth, estimate, case_weights = NULL) {
   case_weights <- case_weights[not_missing]
 
   # Normalize weights (in case negative weights)
+  # subtracting max to avoid Inf in calculations
+  #  exp(x - max(x)) / sum(exp(x - max(x)))
+  #  = (exp(x) / exp(max(x))) / (sum(exp(x)) / exp(max(x)))
+  #  = exp(x) / sum(exp(x))
+  case_weights <- case_weights - max(case_weights)
   case_weights <- exp(case_weights) / sum(exp(case_weights))
 
   res <- sum(resids * case_weights) / (2 * sum(case_weights))

--- a/tests/testthat/test-prob-brier_class.R
+++ b/tests/testthat/test-prob-brier_class.R
@@ -107,3 +107,15 @@ test_that("range values are correct", {
     expect_gte(brier_class_vec(df$truth, df$off), worst)
   }
 })
+
+test_that("doesn't produce NaN with high valued case weights (#614)", {
+  df <- two_class_example
+
+  wts <- rep(1, (nrow(df)))
+  wts_high <- wts * 5000
+
+  expect_identical(
+    brier_class_vec(df$truth, df$Class1, case_weights = wts),
+    brier_class_vec(df$truth, df$Class1, case_weights = wts_high)
+  )
+})


### PR DESCRIPTION
to close #614

``` r
library("yardstick")
library("hardhat")

# Minimal test data (6 rows) that reproduces the bug
# Pardon the weirdness of the data, I excerpted it from my real dataset.
test_data <- structure(list(market_desc = structure(c(2L, 1L, 2L, 1L, 2L, 
                                                      3L), levels = c("Jumbo", "Large", "Medium", "Small"), label = "MARKET_DESC", class = "factor"), 
                            .pred_Jumbo = c(0.0175137900996568, 0.905673347893833, 0.180545683835453, 
                                            0.848162698412699, 0.307261965811966, 0.114002136752137), 
                            .pred_Large = c(0.134188003615333, 0.0939579803556534, 0.818991960147227, 
                                            0.136926984126984, 0.59858021978022, 0.36792673992674), .pred_Medium = c(0.830772931559736, 
                                                                                                                     0.000368671750513363, 0.000462356017320014, 0.0149103174603175, 
                                                                                                                     0.0941578144078144, 0.517671123321123), .pred_Small = c(0.0175252747252747, 
                                                                                                                                                                             0, 0, 0, 0, 4e-04), weighting = structure(c(5L, 3000L, 1400L, 
                                                                                                                                                                                                                         6L, 22L, 28L), class = c("hardhat_frequency_weights", "hardhat_case_weights", 
                                                                                                                                                                                                                                                  "vctrs_vctr"))), row.names = c(NA, -6L), class = c("tbl_df", 
                                                                                                                                                                                                                                                                                                     "tbl", "data.frame"))

# TEST 1: brier_class WITHOUT case_weights - WORKS
brier_class(
  test_data,
  truth = market_desc,
  .pred_Jumbo:.pred_Small
)
#> # A tibble: 1 × 3
#>   .metric     .estimator .estimate
#>   <chr>       <chr>          <dbl>
#> 1 brier_class multiclass     0.184


# TEST 2: brier_class WITH case_weights - RETURNS NaN (BUG)
brier_class(
  test_data,
  truth = market_desc,
  .pred_Jumbo:.pred_Small,
  case_weights = weighting
)
#> # A tibble: 1 × 3
#>   .metric     .estimator .estimate
#>   <chr>       <chr>          <dbl>
#> 1 brier_class multiclass   0.00886
```

<sup>Created on 2026-01-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>